### PR TITLE
v2.2.88: Critical fixes for Phase 2 scan, UI counts, and visual corruption

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.88] - 2025-09-01
+
+### Fixed
+- **Fixed Phase 2 scan getting stuck with 0 files processed**
+  - Removed obsolete `deep_scan` column constraint that was causing database insert failures
+  - Phase 2 (adding files) now properly processes discovered files
+  - Created migration to handle legacy database schema issues
+  
+- **Fixed UI showing incorrect counts for corrupted and warning files**
+  - Files with both corruption AND warnings are now properly counted as corrupted
+  - Warning count now only includes files with warnings that are NOT corrupted
+  - Visual corruption detection results now correctly appear in corrupted files filter
+  
+- **Fixed regression where files with visual corruption were marked as warnings**
+  - Enhanced corruption detection (frame integrity, temporal outliers) now properly marks files as corrupted
+  - Files with visual corruption will appear when filtering for corrupted files in scan results table
+  - Proper categorization: corrupted status takes precedence over warning status
+
+### Changed
+- Reverted test optimization to ensure all media samples are properly scanned during testing
+
 ## [2.2.87] - 2025-08-31
 
 ### Changed

--- a/migrations/remove_deep_scan_column.sql
+++ b/migrations/remove_deep_scan_column.sql
@@ -1,0 +1,8 @@
+-- Remove deep_scan column that was supposed to be removed in v2.2.79
+-- This migration fixes the Phase 2 stuck issue where inserts fail due to NOT NULL constraint
+
+ALTER TABLE scan_results ALTER COLUMN deep_scan DROP NOT NULL;
+ALTER TABLE scan_results ALTER COLUMN deep_scan SET DEFAULT FALSE;
+
+-- Eventually we can drop the column entirely, but for now just make it nullable 
+-- to prevent insert failures while maintaining backwards compatibility

--- a/pixelprobe/api/stats_routes.py
+++ b/pixelprobe/api/stats_routes.py
@@ -43,10 +43,10 @@ def get_stats():
                     SUM(CASE WHEN scan_status = 'pending' AND is_corrupted IS NULL THEN 1 ELSE 0 END) as pending_files,
                     SUM(CASE WHEN scan_status = 'scanning' THEN 1 ELSE 0 END) as scanning_files,
                     SUM(CASE WHEN scan_status = 'error' THEN 1 ELSE 0 END) as error_files,
-                    SUM(CASE WHEN is_corrupted = TRUE AND marked_as_good = FALSE AND (has_warnings = FALSE OR has_warnings IS NULL) THEN 1 ELSE 0 END) as corrupted_files,
+                    SUM(CASE WHEN is_corrupted = TRUE AND marked_as_good = FALSE THEN 1 ELSE 0 END) as corrupted_files,
                     SUM(CASE WHEN (is_corrupted = FALSE AND scan_status = 'completed') OR marked_as_good = TRUE THEN 1 ELSE 0 END) as healthy_files,
                     SUM(CASE WHEN marked_as_good = TRUE THEN 1 ELSE 0 END) as marked_as_good,
-                    SUM(CASE WHEN has_warnings = TRUE AND marked_as_good = FALSE THEN 1 ELSE 0 END) as warning_files
+                    SUM(CASE WHEN has_warnings = TRUE AND marked_as_good = FALSE AND (is_corrupted = FALSE OR is_corrupted IS NULL) THEN 1 ELSE 0 END) as warning_files
                 FROM scan_results
             """)
         ).fetchone()
@@ -78,15 +78,17 @@ def get_stats():
             error_files = ScanResult.query.filter_by(scan_status='error').count()
             
             # Count files, excluding marked_as_good from corrupted and warning counts
+            # Corrupted files include ALL files marked as corrupted (regardless of warnings)
             corrupted_files = ScanResult.query.filter(
                 (ScanResult.is_corrupted == True) & 
-                (ScanResult.marked_as_good == False) &
-                ((ScanResult.has_warnings == False) | (ScanResult.has_warnings == None))
+                (ScanResult.marked_as_good == False)
             ).count()
             
+            # Warning files are those with warnings but NOT corrupted
             warning_files = ScanResult.query.filter(
                 (ScanResult.has_warnings == True) &
-                (ScanResult.marked_as_good == False)
+                (ScanResult.marked_as_good == False) &
+                ((ScanResult.is_corrupted == False) | (ScanResult.is_corrupted == None))
             ).count()
             
             marked_as_good = ScanResult.query.filter_by(marked_as_good=True).count()
@@ -133,7 +135,7 @@ def get_system_info():
                     SUM(CASE WHEN is_corrupted = TRUE AND marked_as_good = FALSE THEN 1 ELSE 0 END) as corrupted_files,
                     SUM(CASE WHEN (is_corrupted = FALSE AND scan_status = 'completed') OR marked_as_good = TRUE THEN 1 ELSE 0 END) as healthy_files,
                     SUM(CASE WHEN marked_as_good = TRUE THEN 1 ELSE 0 END) as marked_as_good,
-                    SUM(CASE WHEN has_warnings = TRUE THEN 1 ELSE 0 END) as warning_files
+                    SUM(CASE WHEN has_warnings = TRUE AND marked_as_good = FALSE AND (is_corrupted = FALSE OR is_corrupted IS NULL) THEN 1 ELSE 0 END) as warning_files
                 FROM scan_results
             """)
         ).fetchone()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,7 +311,7 @@ def mock_scan_result(db):
 
 @pytest.fixture
 def real_scan_results(db, test_data_dir):
-    """Scan real media files into test database - optimized for faster execution"""
+    """Scan real media files into test database"""
     from models import ScanResult
     from media_checker import PixelProbe
     from datetime import datetime, timezone
@@ -319,69 +319,51 @@ def real_scan_results(db, test_data_dir):
     checker = PixelProbe()
     results = []
     
-    # Limit the number of files to scan to prevent timeouts
-    MAX_FILES_PER_TYPE = 3
-    valid_files_scanned = 0
-    corrupted_files_scanned = 0
-    
-    # Only scan essential file types for faster tests
-    essential_extensions = ['.mp4', '.jpg', '.png', '.mp3']
-    
-    # Scan valid files (limited)
+    # Scan valid files
     for key, path in test_data_dir.items():
-        if valid_files_scanned >= MAX_FILES_PER_TYPE:
-            break
         if key.startswith('valid_') and os.path.exists(path):
-            # Only scan essential file types
-            if any(path.endswith(ext) for ext in essential_extensions):
-                scan_data = checker.scan_file(path)
-                if scan_data:
-                    result = ScanResult(
-                        file_path=path,
-                        file_size=scan_data.get('file_size', 0),
-                        file_type=scan_data.get('file_type', ''),
-                        file_hash=scan_data.get('file_hash', ''),
-                        scan_date=datetime.now(timezone.utc),
-                        scan_status='completed',
-                        is_corrupted=scan_data.get('is_corrupted', False),
-                        error_message=scan_data.get('error_message'),
-                        corruption_details=scan_data.get('corruption_details'),
-                        scan_tool=scan_data.get('scan_tool', 'ffmpeg'),
-                        scan_output=scan_data.get('scan_output'),
-                        warning_details=scan_data.get('warning_details'),
-                        marked_as_good=False
-                    )
-                    db.session.add(result)
-                    results.append(result)
-                    valid_files_scanned += 1
+            scan_data = checker.scan_file(path)
+            if scan_data:
+                result = ScanResult(
+                    file_path=path,
+                    file_size=scan_data.get('file_size', 0),
+                    file_type=scan_data.get('file_type', ''),
+                    file_hash=scan_data.get('file_hash', ''),
+                    scan_date=datetime.now(timezone.utc),
+                    scan_status='completed',
+                    is_corrupted=scan_data.get('is_corrupted', False),
+                    error_message=scan_data.get('error_message'),
+                    corruption_details=scan_data.get('corruption_details'),
+                    scan_tool=scan_data.get('scan_tool', 'ffmpeg'),
+                    scan_output=scan_data.get('scan_output'),
+                    warning_details=scan_data.get('warning_details'),
+                    marked_as_good=False
+                )
+                db.session.add(result)
+                results.append(result)
     
-    # Scan corrupted files (limited)
+    # Scan corrupted files
     for key, path in test_data_dir.items():
-        if corrupted_files_scanned >= MAX_FILES_PER_TYPE:
-            break
         if key.startswith('corrupted_') and os.path.exists(path):
-            # Only scan essential file types
-            if any(path.endswith(ext) for ext in essential_extensions):
-                scan_data = checker.scan_file(path)
-                if scan_data:
-                    result = ScanResult(
-                        file_path=path,
-                        file_size=scan_data.get('file_size', 0),
-                        file_type=scan_data.get('file_type', ''),
-                        file_hash=scan_data.get('file_hash', ''),
-                        scan_date=datetime.now(timezone.utc),
-                        scan_status='completed',
-                        is_corrupted=scan_data.get('is_corrupted', False),
-                        error_message=scan_data.get('error_message'),
-                        corruption_details=scan_data.get('corruption_details'),
-                        scan_tool=scan_data.get('scan_tool', 'ffmpeg'),
-                        scan_output=scan_data.get('scan_output'),
-                        warning_details=scan_data.get('warning_details'),
-                        marked_as_good=False
-                    )
-                    db.session.add(result)
-                    results.append(result)
-                    corrupted_files_scanned += 1
+            scan_data = checker.scan_file(path)
+            if scan_data:
+                result = ScanResult(
+                    file_path=path,
+                    file_size=scan_data.get('file_size', 0),
+                    file_type=scan_data.get('file_type', ''),
+                    file_hash=scan_data.get('file_hash', ''),
+                    scan_date=datetime.now(timezone.utc),
+                    scan_status='completed',
+                    is_corrupted=scan_data.get('is_corrupted', False),
+                    error_message=scan_data.get('error_message'),
+                    corruption_details=scan_data.get('corruption_details'),
+                    scan_tool=scan_data.get('scan_tool', 'ffmpeg'),
+                    scan_output=scan_data.get('scan_output'),
+                    warning_details=scan_data.get('warning_details'),
+                    marked_as_good=False
+                )
+                db.session.add(result)
+                results.append(result)
     
     db.session.commit()
     return results

--- a/version.py
+++ b/version.py
@@ -2,7 +2,7 @@
 import os
 
 # Default version - this is the single source of truth
-_DEFAULT_VERSION = '2.2.87'
+_DEFAULT_VERSION = '2.2.88'
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version
 __version__ = os.environ.get('APP_VERSION', _DEFAULT_VERSION)


### PR DESCRIPTION
## Summary
- Fixed Phase 2 scan getting stuck with 0 files processed
- Fixed UI showing incorrect counts for corrupted and warning files  
- Fixed regression where files with visual corruption were marked as warnings

## Details

### 1. Phase 2 Stuck Issue
- Root cause: Database had `deep_scan` column with NOT NULL constraint after v2.2.79 removal
- Fix: Created migration to handle schema mismatch

### 2. UI Count Regression
- Root cause: SQL query excluded files with both corruption AND warnings from corrupted count
- Fix: Updated counting logic - corrupted files counted as corrupted regardless of warnings

### 3. Visual Corruption Classification
- Root cause: Same as UI counts - visual corruption files often have warnings too
- Fix: Ensured corrupted status takes precedence over warning status

## Test Plan
- [x] All tests pass
- [ ] Deploy to test environment
- [ ] Verify Phase 2 processes files correctly
- [ ] Verify UI counts are accurate
- [ ] Verify visual corruption shows in corrupted filter