### PR TITLE
Dependency upgrades + SAWarning fix (v2.5.70)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -48,7 +48,7 @@ jobs:
         pytest -m "not real_media" --cov=pixelprobe --cov-report=xml --cov-report=term
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         flags: unittests

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.5.69] - 2026-03-14
+
+### Security
+
+- **Pillow 10.0.0 -> 12.1.1**: CVE-2023-50447 (CRITICAL 9.8, arbitrary code execution), CVE-2024-28219 (HIGH)
+- **Jinja2 (transitive via Flask 3.1.3)**: CVE-2025-27516 (CRITICAL, sandbox breakout)
+- **Werkzeug 2.3.7 -> 3.1.6**: CVE-2024-34069 (HIGH, RCE via debugger), CVE-2023-46136 (HIGH, DoS)
+- **gunicorn 21.2.0 -> 23.0.0**: CVE-2024-1135, CVE-2024-6827 (HIGH 7.5, HTTP request smuggling)
+- **requests 2.31.0 -> 2.32.5**: CVE-2024-35195 (MEDIUM, TLS bypass), CVE-2024-47081 (MEDIUM, credential leak)
+
+### Changed
+
+- **Flask 2.3.3 -> 3.1.3**: Major upgrade required for Werkzeug 3.x compatibility
+- **Werkzeug safe_join import**: Moved from `werkzeug.security` to `werkzeug.utils` (Werkzeug 3.x)
+- **Pillow transpose API**: Updated `Image.FLIP_LEFT_RIGHT` to `Image.Transpose.FLIP_LEFT_RIGHT` (Pillow 12 deprecation)
+- **Replaced all `Model.query.get(id)` with `db.session.get(Model, id)`**: 43 occurrences across 12 files -- `query.get()` is deprecated in SQLAlchemy 2.x / Flask-SQLAlchemy 3.x
+- **Upgraded Flask ecosystem**: Flask-SQLAlchemy 3.1.1, Flask-CORS 5.0.1, Flask-Limiter 3.9.0, Flask-WTF 1.2.2, flask-restx 1.3.2
+- **Upgraded supporting packages**: pillow-heif 0.22.0, SQLAlchemy 2.0.41, psycopg2-binary 2.9.10, celery 5.4.0, redis 5.2.1, reportlab 4.2.5, PyYAML 6.0.2, bcrypt 4.3.0, APScheduler 3.11.0
+- **Upgraded test dependencies**: pytest 8.3.5, pytest-cov 6.1.1, types-requests 2.32.x
+- Updated docker-compose.yml image tags to 2.5.69
+
+---
+
 ## [2.5.67] - 2026-03-05
 
 ### Fixed

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.5.70] - 2026-03-14
+
+### Fixed
+
+- SQLAlchemy SAWarning during chunk scanning caused by autoflush when accessing chunk attributes after commit
+
 ## [2.5.69] - 2026-03-14
 
 ### Security

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **gunicorn 21.2.0 -> 23.0.0**: CVE-2024-1135, CVE-2024-6827 (HIGH 7.5, HTTP request smuggling)
 - **requests 2.31.0 -> 2.32.5**: CVE-2024-35195 (MEDIUM, TLS bypass), CVE-2024-47081 (MEDIUM, credential leak)
 
+### Fixed
+
+- **RequestsDependencyWarning on worker startup**: Removed system `python3-chardet` 7.1.0 from Docker image that conflicted with requests' version check (fires on every gunicorn/celery worker start)
+- **Node.js 20 deprecation warnings in CI**: Updated `actions/checkout` v3->v4, `actions/setup-python` v4->v5, `codecov/codecov-action` v3->v5
+
 ### Changed
 
 - **Flask 2.3.3 -> 3.1.3**: Major upgrade required for Werkzeug 3.x compatibility

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Upgraded supporting packages**: pillow-heif 0.22.0, SQLAlchemy 2.0.41, psycopg2-binary 2.9.10, celery 5.4.0, redis 5.2.1, reportlab 4.2.5, PyYAML 6.0.2, bcrypt 4.3.0, APScheduler 3.11.0
 - **Upgraded test dependencies**: pytest 8.3.5, pytest-cov 6.1.1, types-requests 2.32.x
 - Updated docker-compose.yml image tags to 2.5.69
+- Updated CI test matrix from Python 3.9/3.10/3.11 to 3.10/3.11/3.12 (Pillow 12 requires Python >= 3.10; Python 3.9 is EOL)
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ RUN ffmpeg -version && \
 
 COPY requirements.txt .
 # Ubuntu 24.04 requires --break-system-packages for pip install in Docker
-RUN pip install --no-cache-dir --break-system-packages -r requirements.txt
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed -r requirements.txt
 
 COPY package.json webpack.config.js ./
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,10 @@ RUN ffmpeg -version && \
 
 COPY requirements.txt .
 # Ubuntu 24.04 requires --break-system-packages for pip install in Docker
-RUN pip install --no-cache-dir --break-system-packages --ignore-installed -r requirements.txt
+# After install, remove chardet (pulled in by reportlab) -- its 7.x version fails
+# requests' version check (requires <6.0.0). Our app uses charset_normalizer instead.
+RUN pip install --no-cache-dir --break-system-packages --ignore-installed -r requirements.txt \
+    && pip uninstall -y chardet --break-system-packages 2>/dev/null; true
 
 COPY package.json webpack.config.js ./
 RUN npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   # PixelProbe application
   pixelprobe:
-    image: ttlequals0/pixelprobe:2.5.67
+    image: ttlequals0/pixelprobe:2.5.69
     container_name: pixelprobe-app
     environment:
       # Security
@@ -126,7 +126,7 @@ services:
 
   # P1 Celery Worker for distributed task processing
   celery-worker:
-    image: ttlequals0/pixelprobe:2.5.67
+    image: ttlequals0/pixelprobe:2.5.69
     container_name: pixelprobe-celery-worker
     command: python celery_worker.py
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   # PixelProbe application
   pixelprobe:
-    image: ttlequals0/pixelprobe:2.5.69
+    image: ttlequals0/pixelprobe:2.5.70
     container_name: pixelprobe-app
     environment:
       # Security
@@ -126,7 +126,7 @@ services:
 
   # P1 Celery Worker for distributed task processing
   celery-worker:
-    image: ttlequals0/pixelprobe:2.5.69
+    image: ttlequals0/pixelprobe:2.5.70
     container_name: pixelprobe-celery-worker
     command: python celery_worker.py
     environment:

--- a/pixelprobe/api/admin_routes.py
+++ b/pixelprobe/api/admin_routes.py
@@ -98,7 +98,7 @@ def mark_as_good():
     
     try:
         for file_id in file_ids:
-            result = ScanResult.query.get(file_id)
+            result = db.session.get(ScanResult, file_id)
             if result:
                 result.marked_as_good = True
                 result.is_corrupted = False
@@ -180,7 +180,7 @@ def add_ignored_pattern():
 @auth_required
 def delete_ignored_pattern(pattern_id):
     """Delete an ignored error pattern"""
-    pattern = IgnoredErrorPattern.query.get(pattern_id)
+    pattern = db.session.get(IgnoredErrorPattern, pattern_id)
     if not pattern:
         return {'error': 'Pattern not found'}, 404
     
@@ -273,7 +273,7 @@ def get_schedules():
 @auth_required
 def get_schedule(schedule_id):
     """Get a specific scan schedule by ID"""
-    schedule = ScanSchedule.query.get_or_404(schedule_id)
+    schedule = db.get_or_404(ScanSchedule, schedule_id)
     return jsonify(schedule.to_dict())
 
 @admin_bp.route('/schedules', methods=['POST'])
@@ -320,7 +320,7 @@ def create_schedule():
 @auth_required
 def update_schedule(schedule_id):
     """Update a scan schedule"""
-    schedule = ScanSchedule.query.get_or_404(schedule_id)
+    schedule = db.get_or_404(ScanSchedule, schedule_id)
     data = request.get_json()
 
     try:
@@ -370,7 +370,7 @@ def update_schedule(schedule_id):
 @auth_required
 def delete_schedule(schedule_id):
     """Delete a scan schedule"""
-    schedule = ScanSchedule.query.get_or_404(schedule_id)
+    schedule = db.get_or_404(ScanSchedule, schedule_id)
     
     try:
         # Actually delete the schedule from database instead of soft delete

--- a/pixelprobe/api/auth_routes.py
+++ b/pixelprobe/api/auth_routes.py
@@ -161,15 +161,13 @@ def delete_user(user_id):
     if user.id == user_id:
         return jsonify({'error': 'Cannot delete your own account'}), 400
 
-    # Prevent deleting the last admin
-    if User.query.filter_by(is_admin=True).count() == 1:
-        user_to_delete = User.query.get(user_id)
-        if user_to_delete and user_to_delete.is_admin:
-            return jsonify({'error': 'Cannot delete the last admin user'}), 400
-
-    user_to_delete = User.query.get(user_id)
+    user_to_delete = db.session.get(User, user_id)
     if not user_to_delete:
         return jsonify({'error': 'User not found'}), 404
+
+    # Prevent deleting the last admin
+    if user_to_delete.is_admin and User.query.filter_by(is_admin=True).count() == 1:
+        return jsonify({'error': 'Cannot delete the last admin user'}), 400
 
     try:
         db.session.delete(user_to_delete)
@@ -198,7 +196,7 @@ def change_password(user_id):
     if not new_password or len(new_password) < 8:
         return jsonify({'error': 'New password must be at least 8 characters'}), 400
 
-    target_user = User.query.get(user_id)
+    target_user = db.session.get(User, user_id)
     if not target_user:
         return jsonify({'error': 'User not found'}), 404
 

--- a/pixelprobe/api/export_routes.py
+++ b/pixelprobe/api/export_routes.py
@@ -26,7 +26,7 @@ def view_file(result_id):
         response.headers['Access-Control-Max-Age'] = '3600'
         return response
     
-    result = ScanResult.query.get_or_404(result_id)
+    result = db.get_or_404(ScanResult, result_id)
     
     logger.info(f"View requested for file: {result.file_path} (ID: {result_id})")
     
@@ -104,7 +104,7 @@ def view_file(result_id):
 @auth_required
 def download_file(result_id):
     """Download a media file"""
-    result = ScanResult.query.get_or_404(result_id)
+    result = db.get_or_404(ScanResult, result_id)
     
     logger.info(f"Download requested for file: {result.file_path} (ID: {result_id})")
     

--- a/pixelprobe/api/healthcheck_routes.py
+++ b/pixelprobe/api/healthcheck_routes.py
@@ -55,7 +55,7 @@ def get_healthcheck_config(config_id):
         JSON healthcheck configuration details
     """
     try:
-        config = HealthcheckConfig.query.get(config_id)
+        config = db.session.get(HealthcheckConfig, config_id)
 
         if not config:
             return jsonify({'error': 'Healthcheck configuration not found'}), 404
@@ -140,7 +140,7 @@ def create_healthcheck_config():
         healthcheck_url = data['healthcheck_url']
 
         # Verify schedule exists
-        schedule = ScanSchedule.query.get(schedule_id)
+        schedule = db.session.get(ScanSchedule, schedule_id)
         if not schedule:
             return jsonify({'error': f'Schedule {schedule_id} not found'}), 404
 
@@ -204,7 +204,7 @@ def update_healthcheck_config(config_id):
         JSON updated healthcheck configuration
     """
     try:
-        config = HealthcheckConfig.query.get(config_id)
+        config = db.session.get(HealthcheckConfig, config_id)
 
         if not config:
             return jsonify({'error': 'Healthcheck configuration not found'}), 404
@@ -271,7 +271,7 @@ def delete_healthcheck_config(config_id):
         JSON success message
     """
     try:
-        config = HealthcheckConfig.query.get(config_id)
+        config = db.session.get(HealthcheckConfig, config_id)
 
         if not config:
             return jsonify({'error': 'Healthcheck configuration not found'}), 404
@@ -303,7 +303,7 @@ def test_healthcheck(config_id):
         JSON test result
     """
     try:
-        config = HealthcheckConfig.query.get(config_id)
+        config = db.session.get(HealthcheckConfig, config_id)
 
         if not config:
             return jsonify({'error': 'Healthcheck configuration not found'}), 404

--- a/pixelprobe/api/maintenance_routes.py
+++ b/pixelprobe/api/maintenance_routes.py
@@ -522,7 +522,7 @@ def cleanup_orphaned_async(app, cleanup_id, file_paths=None, schedule_id=None):
             with db.session.get_bind().connect() as connection:
                 with db.session():
                     # Get the cleanup record
-                    cleanup_record = CleanupState.query.get(cleanup_id)
+                    cleanup_record = db.session.get(CleanupState, cleanup_id)
                     if not cleanup_record:
                         logger.error(f"Cleanup record {cleanup_id} not found")
                         return
@@ -538,7 +538,7 @@ def cleanup_orphaned_async(app, cleanup_id, file_paths=None, schedule_id=None):
         logger.error(f"Error in cleanup_orphaned_async: {str(e)}")
         try:
             with app.app_context():
-                cleanup_record = CleanupState.query.get(cleanup_id)
+                cleanup_record = db.session.get(CleanupState, cleanup_id)
                 if cleanup_record:
                     cleanup_record.phase = 'error'
                     cleanup_record.progress_message = f'Error: {str(e)}'

--- a/pixelprobe/api/notification_routes.py
+++ b/pixelprobe/api/notification_routes.py
@@ -58,7 +58,7 @@ def get_provider(provider_id):
         JSON provider details
     """
     try:
-        provider = NotificationProvider.query.get(provider_id)
+        provider = db.session.get(NotificationProvider, provider_id)
         if not provider:
             return jsonify({'error': 'Provider not found'}), 404
 
@@ -143,7 +143,7 @@ def update_provider(provider_id):
         JSON updated provider
     """
     try:
-        provider = NotificationProvider.query.get(provider_id)
+        provider = db.session.get(NotificationProvider, provider_id)
         if not provider:
             return jsonify({'error': 'Provider not found'}), 404
 
@@ -187,7 +187,7 @@ def delete_provider(provider_id):
         Empty response with 204 status
     """
     try:
-        provider = NotificationProvider.query.get(provider_id)
+        provider = db.session.get(NotificationProvider, provider_id)
         if not provider:
             return jsonify({'error': 'Provider not found'}), 404
 
@@ -216,7 +216,7 @@ def test_provider(provider_id):
         JSON with test result
     """
     try:
-        provider = NotificationProvider.query.get(provider_id)
+        provider = db.session.get(NotificationProvider, provider_id)
         if not provider:
             return jsonify({'error': 'Provider not found'}), 404
 
@@ -274,7 +274,7 @@ def get_rule(rule_id):
         JSON rule details
     """
     try:
-        rule = NotificationRule.query.get(rule_id)
+        rule = db.session.get(NotificationRule, rule_id)
         if not rule:
             return jsonify({'error': 'Rule not found'}), 404
         return jsonify(rule.to_dict()), 200
@@ -315,7 +315,7 @@ def create_rule():
             return jsonify({'error': f'Invalid event type. Must be one of: {VALID_EVENT_TYPES}'}), 400
 
         # Verify provider exists
-        provider = NotificationProvider.query.get(provider_id)
+        provider = db.session.get(NotificationProvider, provider_id)
         if not provider:
             return jsonify({'error': 'Provider not found'}), 404
 
@@ -362,7 +362,7 @@ def update_rule(rule_id):
         JSON updated rule
     """
     try:
-        rule = NotificationRule.query.get(rule_id)
+        rule = db.session.get(NotificationRule, rule_id)
         if not rule:
             return jsonify({'error': 'Rule not found'}), 404
 
@@ -410,7 +410,7 @@ def delete_rule(rule_id):
         Empty response with 204 status
     """
     try:
-        rule = NotificationRule.query.get(rule_id)
+        rule = db.session.get(NotificationRule, rule_id)
         if not rule:
             return jsonify({'error': 'Rule not found'}), 404
 

--- a/pixelprobe/api/scan_routes.py
+++ b/pixelprobe/api/scan_routes.py
@@ -299,7 +299,7 @@ def get_scan_results():
 @auth_required
 def get_scan_result(result_id):
     """Get a single scan result by ID"""
-    result = ScanResult.query.get_or_404(result_id)
+    result = db.get_or_404(ScanResult, result_id)
     result_dict = result.to_dict()
     
     # Convert timestamps to configured timezone for display
@@ -1609,7 +1609,7 @@ def get_worker_status():
 @auth_required
 def get_scan_output(result_id):
     """Get the detailed scan output for a specific result"""
-    result = ScanResult.query.get_or_404(result_id)
+    result = db.get_or_404(ScanResult, result_id)
     
     return {
         'id': result.id,

--- a/pixelprobe/auth.py
+++ b/pixelprobe/auth.py
@@ -85,7 +85,7 @@ def init_auth(app):
 
     @login_manager.user_loader
     def load_user(user_id):
-        user = User.query.get(int(user_id))
+        user = db.session.get(User, int(user_id))
         if user:
             # Force load all attributes to prevent lazy loading issues
             _ = user.is_active

--- a/pixelprobe/media_checker.py
+++ b/pixelprobe/media_checker.py
@@ -893,7 +893,7 @@ class PixelProbe:
                 # Note: After load(), tile data is consumed and cleared in PIL - this is normal behavior
                 # Removed incorrect tile data check that was causing false positives
                 
-                    img.transpose(Image.FLIP_LEFT_RIGHT)
+                    img.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
                     scan_output.append("Transform test: PASSED")
             
             except Exception as e:

--- a/pixelprobe/repositories/base_repository.py
+++ b/pixelprobe/repositories/base_repository.py
@@ -17,7 +17,7 @@ class BaseRepository(Generic[T]):
     
     def get_by_id(self, id: int) -> Optional[T]:
         """Get a single record by ID"""
-        return self.session.query(self.model_class).get(id)
+        return self.session.get(self.model_class, id)
     
     def get_all(self) -> List[T]:
         """Get all records"""

--- a/pixelprobe/scheduler.py
+++ b/pixelprobe/scheduler.py
@@ -349,7 +349,7 @@ class MediaScheduler:
                     logger.warning(f"Scheduled scan {schedule_id} skipped - another scan is already running (phase: {scan_state.phase})")
                     return
 
-                schedule = ScanSchedule.query.get(schedule_id)
+                schedule = db.session.get(ScanSchedule, schedule_id)
                 if not schedule or not schedule.is_active:
                     return
 
@@ -496,10 +496,10 @@ class MediaScheduler:
         
     def update_schedule(self, schedule_id: int, **kwargs) -> ScanSchedule:
         """Update an existing schedule"""
-        schedule = ScanSchedule.query.get(schedule_id)
+        schedule = db.session.get(ScanSchedule, schedule_id)
         if not schedule:
             raise ValueError(f"Schedule {schedule_id} not found")
-            
+
         # Remove old job
         job_id = f"schedule_{schedule_id}"
         try:
@@ -524,10 +524,10 @@ class MediaScheduler:
         
     def delete_schedule(self, schedule_id: int):
         """Delete a schedule"""
-        schedule = ScanSchedule.query.get(schedule_id)
+        schedule = db.session.get(ScanSchedule, schedule_id)
         if not schedule:
             raise ValueError(f"Schedule {schedule_id} not found")
-            
+
         # Remove job
         job_id = f"schedule_{schedule_id}"
         try:
@@ -683,7 +683,7 @@ class MediaScheduler:
 
             with app.app_context():
                 # Get the scan report
-                scan_report = ScanReport.query.get(scan_report_id)
+                scan_report = db.session.get(ScanReport, scan_report_id)
                 if not scan_report:
                     logger.warning(f"Scan report {scan_report_id} not found for healthcheck ping")
                     return

--- a/pixelprobe/services/maintenance_service.py
+++ b/pixelprobe/services/maintenance_service.py
@@ -330,7 +330,7 @@ class MaintenanceService:
         # Store schedule_id for report creation
         self._cleanup_schedule_id = schedule_id
         try:
-            cleanup_record = CleanupState.query.get(cleanup_id)
+            cleanup_record = db.session.get(CleanupState, cleanup_id)
             if not cleanup_record:
                 logger.error(f"Cleanup record not found: {cleanup_id}")
                 return
@@ -575,7 +575,7 @@ class MaintenanceService:
 
             # Try to create error report
             try:
-                cleanup_record = CleanupState.query.get(cleanup_id)
+                cleanup_record = db.session.get(CleanupState, cleanup_id)
                 if cleanup_record:
                     self._create_cleanup_report(cleanup_record, getattr(self, 'orphaned_files_list', []))
             except Exception as report_error:
@@ -1172,7 +1172,7 @@ class MaintenanceService:
     def _handle_cleanup_error(self, cleanup_id: int, error_msg: str):
         """Handle cleanup error"""
         try:
-            cleanup_record = CleanupState.query.get(cleanup_id)
+            cleanup_record = db.session.get(CleanupState, cleanup_id)
             if cleanup_record:
                 cleanup_record.phase = 'error'
                 cleanup_record.is_active = False

--- a/pixelprobe/services/scan_service.py
+++ b/pixelprobe/services/scan_service.py
@@ -2374,69 +2374,72 @@ class ScanService:
         
         try:
             import json as json_module
-            # Check if this is a file-based chunk (Phase 3)
-            if chunk.directory_path.startswith('{'):
-                # New FCP (File Chunk Paths) JSON format
-                try:
-                    chunk_meta = json_module.loads(chunk.directory_path)
-                    if chunk_meta.get('t') == 'FCP':
-                        first_path = chunk_meta['f']
-                        last_path = chunk_meta['l']
-                        # Count pending files in path range
-                        if force_rescan:
-                            files_count = db.session.query(ScanResult).filter(
-                                ScanResult.file_path >= first_path,
-                                ScanResult.file_path <= last_path
-                            ).count()
+            # Disable autoflush to avoid SAWarning when accessing chunk attributes
+            # after commit (same pattern as _get_chunk_file_count)
+            with db.session.no_autoflush:
+                # Check if this is a file-based chunk (Phase 3)
+                if chunk.directory_path.startswith('{'):
+                    # New FCP (File Chunk Paths) JSON format
+                    try:
+                        chunk_meta = json_module.loads(chunk.directory_path)
+                        if chunk_meta.get('t') == 'FCP':
+                            first_path = chunk_meta['f']
+                            last_path = chunk_meta['l']
+                            # Count pending files in path range
+                            if force_rescan:
+                                files_count = db.session.query(ScanResult).filter(
+                                    ScanResult.file_path >= first_path,
+                                    ScanResult.file_path <= last_path
+                                ).count()
+                            else:
+                                files_count = db.session.query(ScanResult).filter(
+                                    ScanResult.file_path >= first_path,
+                                    ScanResult.file_path <= last_path,
+                                    ScanResult.scan_status == 'pending'
+                                ).count()
+                            logger.info(f"FCP chunk {chunk.chunk_id}: Found {files_count} files in path range")
                         else:
-                            files_count = db.session.query(ScanResult).filter(
-                                ScanResult.file_path >= first_path,
-                                ScanResult.file_path <= last_path,
-                                ScanResult.scan_status == 'pending'
-                            ).count()
-                        logger.info(f"FCP chunk {chunk.chunk_id}: Found {files_count} files in path range")
-                    else:
-                        logger.error(f"Unknown chunk type: {chunk_meta.get('t')}")
+                            logger.error(f"Unknown chunk type: {chunk_meta.get('t')}")
+                            files_count = 0
+                    except json_module.JSONDecodeError as e:
+                        logger.error(f"Failed to parse FCP chunk metadata: {e}")
                         files_count = 0
-                except json_module.JSONDecodeError as e:
-                    logger.error(f"Failed to parse FCP chunk metadata: {e}")
-                    files_count = 0
-            elif chunk.directory_path.startswith('FILE_CHUNK:'):
-                # Legacy: Parse the chunk metadata: "FILE_CHUNK:offset:limit"
-                parts = chunk.directory_path.split(':')
-                offset = int(parts[1])
-                limit = int(parts[2])
+                elif chunk.directory_path.startswith('FILE_CHUNK:'):
+                    # Legacy: Parse the chunk metadata: "FILE_CHUNK:offset:limit"
+                    parts = chunk.directory_path.split(':')
+                    offset = int(parts[1])
+                    limit = int(parts[2])
 
-                # Get count for this specific chunk
-                files_count = limit  # We know exactly how many files are in this chunk
-                logger.info(f"FILE_CHUNK {chunk.chunk_id}: Processing {files_count} files (offset={offset})")
-            elif chunk.directory_path == 'PENDING_FILES':
-                # Legacy: Get ALL pending files regardless of directory
-                files_count = db.session.query(ScanResult).filter(
-                    ScanResult.scan_status == 'pending'
-                ).count()
-                logger.info(f"PENDING_FILES chunk: Found {files_count} pending files to scan")
-            else:
-                # Legacy: Query for files in this chunk's directory that need scanning
-                # Simply match all files that start with the directory path
-                chunk_dir = chunk.directory_path.rstrip(os.sep)
-                
-                # Get count first to avoid loading all files into memory
-                if force_rescan:
-                    # Count all files that start with this directory path
+                    # Get count for this specific chunk
+                    files_count = limit  # We know exactly how many files are in this chunk
+                    logger.info(f"FILE_CHUNK {chunk.chunk_id}: Processing {files_count} files (offset={offset})")
+                elif chunk.directory_path == 'PENDING_FILES':
+                    # Legacy: Get ALL pending files regardless of directory
                     files_count = db.session.query(ScanResult).filter(
-                        ScanResult.file_path.startswith(chunk_dir)
+                        ScanResult.scan_status == 'pending'
                     ).count()
+                    logger.info(f"PENDING_FILES chunk: Found {files_count} pending files to scan")
                 else:
-                    # For normal scans, only scan pending files (new/unscanned)
-                    files_count = db.session.query(ScanResult).filter(
-                        db.and_(
-                            ScanResult.file_path.startswith(chunk_dir),
-                            ScanResult.scan_status == 'pending'
-                        )
-                    ).count()
-            
-            logger.info(f"Chunk {chunk.chunk_id}: Found {files_count} files to scan in {chunk.directory_path}")
+                    # Legacy: Query for files in this chunk's directory that need scanning
+                    # Simply match all files that start with the directory path
+                    chunk_dir = chunk.directory_path.rstrip(os.sep)
+
+                    # Get count first to avoid loading all files into memory
+                    if force_rescan:
+                        # Count all files that start with this directory path
+                        files_count = db.session.query(ScanResult).filter(
+                            ScanResult.file_path.startswith(chunk_dir)
+                        ).count()
+                    else:
+                        # For normal scans, only scan pending files (new/unscanned)
+                        files_count = db.session.query(ScanResult).filter(
+                            db.and_(
+                                ScanResult.file_path.startswith(chunk_dir),
+                                ScanResult.scan_status == 'pending'
+                            )
+                        ).count()
+
+                logger.info(f"Chunk {chunk.chunk_id}: Found {files_count} files to scan in {chunk.directory_path}")
             
             scanned = 0
             errors = 0

--- a/pixelprobe/services/scan_service.py
+++ b/pixelprobe/services/scan_service.py
@@ -699,7 +699,7 @@ class ScanService:
             try:
                 run_scan()
                 # Get final scan state for results
-                final_scan_state = ScanState.query.get(scan_state_id)
+                final_scan_state = db.session.get(ScanState, scan_state_id)
                 if final_scan_state:
                     # Get corrupted file count from ScanResult table with retry logic
                     # Note: ScanResult doesn't have scan_id, so we query all corrupted files
@@ -729,7 +729,7 @@ class ScanService:
 
                     # Re-fetch scan_state after potential session closure to avoid DetachedInstanceError
                     # db.session.close() above can detach the original final_scan_state object
-                    final_scan_state = ScanState.query.get(scan_state_id)
+                    final_scan_state = db.session.get(ScanState, scan_state_id)
                     if not final_scan_state:
                         logger.error(f"Could not re-fetch scan_state {scan_state_id} after retry loop")
                         return {
@@ -949,7 +949,7 @@ class ScanService:
             try:
                 run_scan()
                 # Get final scan state for results
-                final_scan_state = ScanState.query.get(scan_state_id)
+                final_scan_state = db.session.get(ScanState, scan_state_id)
                 if final_scan_state:
                     # Get corrupted file count from ScanResult table with retry logic
                     # Note: ScanResult doesn't have scan_id, so we query all corrupted files

--- a/pixelprobe/tasks.py
+++ b/pixelprobe/tasks.py
@@ -543,7 +543,7 @@ def scheduled_scan_task(schedule_id, scan_type='full'):
         from uuid import uuid4
         
         # Get schedule details
-        schedule = ScanSchedule.query.get(schedule_id)
+        schedule = db.session.get(ScanSchedule, schedule_id)
         if not schedule or not schedule.is_active:
             raise ValueError(f"Schedule {schedule_id} not found or inactive")
         

--- a/pixelprobe/tasks_parallel.py
+++ b/pixelprobe/tasks_parallel.py
@@ -44,7 +44,7 @@ def process_chunk_task(self, chunk_id: int, scan_id: str, scan_type: str = 'full
         from flask import current_app
         
         # Get the chunk from database
-        chunk = ScanChunk.query.get(chunk_id)
+        chunk = db.session.get(ScanChunk, chunk_id)
         if not chunk:
             logger.error(f"Chunk {chunk_id} not found")
             return {
@@ -369,7 +369,7 @@ def process_chunk_task(self, chunk_id: int, scan_id: str, scan_type: str = 'full
         else:
             # Mark chunk as failed after max retries
             try:
-                chunk = ScanChunk.query.get(chunk_id)
+                chunk = db.session.get(ScanChunk, chunk_id)
                 if chunk:
                     chunk.error_message = str(exc)
                     db.session.commit()

--- a/pixelprobe/utils/security.py
+++ b/pixelprobe/utils/security.py
@@ -11,7 +11,7 @@ from functools import wraps
 from datetime import datetime, timezone
 from typing import Optional, Set, Tuple, Union
 from flask import request, jsonify, current_app
-from werkzeug.security import safe_join
+from werkzeug.utils import safe_join
 from pixelprobe.models import db, ScanConfiguration
 import requests
 

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.5.68'
+_DEFAULT_VERSION = '2.5.69'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.5.69'
+_DEFAULT_VERSION = '2.5.70'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,8 +5,8 @@
 -r requirements.txt
 
 # Testing frameworks
-pytest==7.4.3
-pytest-cov==4.1.0
+pytest==8.3.5
+pytest-cov==6.1.1
 pytest-benchmark==4.0.0
 pytest-timeout==2.2.0
 pytest-mock==3.12.0
@@ -25,7 +25,7 @@ isort==5.12.0
 
 # Type checking
 mypy==1.7.1
-types-requests==2.31.0.10
+types-requests==2.32.0.20250515
 
 # Documentation
 sphinx==7.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
-Flask==2.3.3
-Flask-SQLAlchemy==3.0.5
-Flask-CORS==4.0.0
-Flask-Limiter==3.5.0
-Flask-WTF==1.2.1
-flask-restx==1.3.0
-Pillow==10.0.0
-pillow-heif==0.13.1  # HEIC/HEIF support for Pillow (requires libheif system library)
+Flask==3.1.3
+Flask-SQLAlchemy==3.1.1
+Flask-CORS==5.0.1
+Flask-Limiter==3.9.0
+Flask-WTF==1.2.2
+flask-restx==1.3.2
+Pillow==12.1.1
+pillow-heif==0.22.0  # HEIC/HEIF support for Pillow (requires libheif system library)
 python-magic==0.4.27
 ffmpeg-python==0.2.0
-SQLAlchemy==2.0.21
+SQLAlchemy==2.0.41
 python-dotenv==1.0.0
-Werkzeug==2.3.7
-gunicorn==21.2.0
+Werkzeug==3.1.6
+gunicorn==23.0.0
 pytz==2023.3
-APScheduler==3.10.4
-requests==2.31.0
-reportlab==4.0.7
+APScheduler==3.11.0
+requests==2.32.5
+reportlab==4.2.5
 psutil==7.0.0
-PyYAML==6.0.1
+PyYAML==6.0.2
 
 # PostgreSQL support
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
 
 # P1 Celery Task Queue Implementation
-celery==5.3.4
-redis==5.0.1
+celery==5.4.0
+redis==5.2.1
 
 # Authentication support
 Flask-Login==0.6.3
-bcrypt==4.1.1
+bcrypt==4.3.0

--- a/tests/integration/test_admin_endpoints.py
+++ b/tests/integration/test_admin_endpoints.py
@@ -65,7 +65,7 @@ class TestScheduleEndpoints:
             assert response.status_code == 204
             
             # Verify hard deleted (schedule no longer exists)
-            schedule = ScanSchedule.query.get(schedule_id)
+            schedule = db.session.get(ScanSchedule, schedule_id)
             assert schedule is None
     
     def test_delete_nonexistent_schedule(self, authenticated_client, db):
@@ -389,7 +389,7 @@ class TestIgnoredPatternsEndpoints:
             assert 'deleted successfully' in response.get_json()['message']
             
             # Verify soft deleted
-            pattern = IgnoredErrorPattern.query.get(pattern_id)
+            pattern = db.session.get(IgnoredErrorPattern, pattern_id)
             assert pattern is not None
             assert pattern.is_active is False
     


### PR DESCRIPTION
## Summary

- Upgrade 18 Python dependencies to fix 9 CVEs (2 CRITICAL, 4 HIGH, 2 MEDIUM)
- Flask 2.3 -> 3.1.3 (major upgrade required for Werkzeug 3.x)
- Pillow 10 -> 12.1.1 (CVE-2023-50447 CRITICAL), Werkzeug 2.3 -> 3.1.6 (RCE/DoS), gunicorn 21 -> 23 (HTTP smuggling), requests 2.31 -> 2.32.5 (TLS bypass)
- Migrate all deprecated `Model.query.get()` -> `db.session.get()` and `get_or_404()` across 15 files
- Update Werkzeug `safe_join` import path and Pillow `Transpose` API for compatibility
- Fix Docker build failure with system PyYAML on Ubuntu 24.04
- Fix `RequestsDependencyWarning` on every worker startup by removing chardet 7.1.0 from Docker image
- Update GitHub Actions (checkout v4, setup-python v5, codecov v5) to resolve Node.js 20 deprecation warnings

## Version
2.5.69

## CVEs Fixed

| Package | CVE | Severity |
|---------|-----|----------|
| Pillow | CVE-2023-50447 | CRITICAL (9.8) |
| Jinja2 (transitive) | CVE-2025-27516 | CRITICAL |
| Werkzeug | CVE-2024-34069 | HIGH (RCE) |
| Werkzeug | CVE-2023-46136 | HIGH (DoS) |
| gunicorn | CVE-2024-1135 | HIGH (7.5) |
| gunicorn | CVE-2024-6827 | HIGH (7.5) |
| Pillow | CVE-2024-28219 | HIGH |
| requests | CVE-2024-35195 | MEDIUM |
| requests | CVE-2024-47081 | MEDIUM |

## Test plan
- [x] All 251 tests pass (8 skipped, same as baseline)
- [x] Zero legacy `LegacyAPIWarning` deprecation warnings remaining
- [x] Docker image built successfully for linux/amd64
- [x] Image pushed to Docker Hub as `ttlequals0/pixelprobe:2.5.69` and `latest`
- [x] No `RequestsDependencyWarning` in Docker image
- [x] CI actions updated to Node.js 24-compatible versions