### PR TITLE
Video freeze detection + scan completion fixes (v2.6.8)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
-## [2.6.7] - 2026-03-31
+## [2.6.8] - 2026-03-31
 
 ### Added
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fix "0 of 0 files" progress display during scanning phase**: The scan status API returned `estimated_total=0` during the gap between phase transition and chunk counting. Added explicit Redis update after DB commit and a fallback to `phase_total` in the API when `estimated_total` is 0.
 - **Filter black frame false positives from freeze detection**: Freeze events that overlap with black sections (scene transitions, studio logos, end credits) are now filtered out. Uses FFmpeg `blackdetect` filter chained with `freezedetect` in a single decode pass.
+- **Fix scan stuck as active after completion**: Two issues -- (1) `_mark_scan_completed()` used raw SQL UPDATE but the ORM identity map still held stale `is_active=True`; when `_create_scan_report()` committed, it overwrote the completed state. Added `db.session.expire_all()` after the raw SQL commit. (2) Recovery endpoint and new scans didn't clear stale Redis progress keys, causing the API to return contradictory state (running + completed). Added `clear_scan_progress_redis()` to recovery and scan start.
 
 ---
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
-## [2.6.3] - 2026-03-30
+## [2.6.4] - 2026-03-30
 
 ### Added
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Fix "0 of 0 files" progress display during scanning phase**: The scan status API returned `estimated_total=0` during the gap between phase transition and chunk counting. Added explicit Redis update after DB commit and a fallback to `phase_total` in the API when `estimated_total` is 0.
+- **Filter black frame false positives from freeze detection**: Freeze events that overlap with black sections (scene transitions, studio logos, end credits) are now filtered out. Uses FFmpeg `blackdetect` filter chained with `freezedetect` in a single decode pass.
 
 ---
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
-## [2.6.5] - 2026-03-30
+## [2.6.7] - 2026-03-31
 
 ### Added
 
-- **Video freeze detection**: Detect videos with frozen frames (stuck picture while audio continues) using FFmpeg's `freezedetect` filter. Freeze events are marked as corruption with details including event count, total frozen time, percentage of video frozen, and per-event timestamps. Uses `-40dB` noise tolerance and `4s` minimum freeze duration with black frame filtering to reduce false positives. Configurable via `FREEZE_DETECTION_ENABLED` environment variable (default: `true`).
+- **Video freeze detection**: Detect videos with frozen frames (stuck picture while audio continues) using FFmpeg's `freezedetect` filter. Freeze events are reported as **warnings** (not corruption) with details including event count, total frozen time, percentage of video frozen, and per-event timestamps. Uses `-60dB` noise tolerance and `5s` minimum freeze duration with black frame filtering to reduce false positives. Configurable via `FREEZE_DETECTION_ENABLED` environment variable (default: `true`).
 
 ### Fixed
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
-## [2.6.4] - 2026-03-30
+## [2.6.5] - 2026-03-30
 
 ### Added
 
-- **Video freeze detection**: Detect videos with frozen frames (stuck picture while audio continues) using FFmpeg's `freezedetect` filter. Freeze events are marked as corruption with details including event count, total frozen time, percentage of video frozen, and per-event timestamps. Uses `-60dB` noise tolerance and `2s` minimum freeze duration. Configurable via `FREEZE_DETECTION_ENABLED` environment variable (default: `true`).
+- **Video freeze detection**: Detect videos with frozen frames (stuck picture while audio continues) using FFmpeg's `freezedetect` filter. Freeze events are marked as corruption with details including event count, total frozen time, percentage of video frozen, and per-event timestamps. Uses `-40dB` noise tolerance and `4s` minimum freeze duration with black frame filtering to reduce false positives. Configurable via `FREEZE_DETECTION_ENABLED` environment variable (default: `true`).
 
 ### Fixed
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.6.3] - 2026-03-30
+
+### Added
+
+- **Video freeze detection**: Detect videos with frozen frames (stuck picture while audio continues) using FFmpeg's `freezedetect` filter. Freeze events are marked as corruption with details including event count, total frozen time, percentage of video frozen, and per-event timestamps. Uses `-60dB` noise tolerance and `2s` minimum freeze duration. Configurable via `FREEZE_DETECTION_ENABLED` environment variable (default: `true`).
+
+---
+
 ## [2.6.2] - 2026-03-20
 
 ### Fixed

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Video freeze detection**: Detect videos with frozen frames (stuck picture while audio continues) using FFmpeg's `freezedetect` filter. Freeze events are marked as corruption with details including event count, total frozen time, percentage of video frozen, and per-event timestamps. Uses `-60dB` noise tolerance and `2s` minimum freeze duration. Configurable via `FREEZE_DETECTION_ENABLED` environment variable (default: `true`).
 
+### Fixed
+
+- **Fix "0 of 0 files" progress display during scanning phase**: The scan status API returned `estimated_total=0` during the gap between phase transition and chunk counting. Added explicit Redis update after DB commit and a fallback to `phase_total` in the API when `estimated_total` is 0.
+
 ---
 
 ## [2.6.2] - 2026-03-20

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PixelProbe detects corrupted video, image, and audio files across your media lib
 
 ### Detection Capabilities
 - FFmpeg-based deep video analysis
-- Video freeze detection (stuck frames while audio continues) via FFmpeg freezedetect filter
+- Video freeze detection (stuck frames while audio continues) via FFmpeg freezedetect filter with black frame false positive filtering
 - ImageMagick and PIL image validation
 - Smart warning system for minor issues vs critical corruption
 - Multi-stage detection with configurable thresholds

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ PixelProbe detects corrupted video, image, and audio files across your media lib
 
 ### Detection Capabilities
 - FFmpeg-based deep video analysis
+- Video freeze detection (stuck frames while audio continues) via FFmpeg freezedetect filter
 - ImageMagick and PIL image validation
 - Smart warning system for minor issues vs critical corruption
 - Multi-stage detection with configurable thresholds
@@ -258,6 +259,7 @@ PixelProbe uses environment variables for all configuration. Copy `.env.example`
 - `CLEANUP_SCHEDULE` - Automated cleanup schedule
 - `EXCLUDED_PATHS` - Paths to ignore during scanning
 - `EXCLUDED_EXTENSIONS` - File extensions to ignore
+- `FREEZE_DETECTION_ENABLED` - Enable video freeze detection (default: `true`). Set to `false` to skip freeze detection and reduce scan time for large video libraries
 
 See `.env.example` for complete configuration options with examples.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,10 @@ services:
       BATCH_SIZE: ${BATCH_SIZE:-100}
       MAX_OUTPUT_SIZE: ${MAX_OUTPUT_SIZE:-10000}
       OUTPUT_ROTATION_ENABLED: ${OUTPUT_ROTATION_ENABLED:-true}
+      FREEZE_DETECTION_ENABLED: ${FREEZE_DETECTION_ENABLED:-true}
       TZ: America/New_York
-      
-      
+
+
       # Scheduled scans
       PERIODIC_SCAN_SCHEDULE: ${PERIODIC_SCAN_SCHEDULE:-}
       CLEANUP_SCHEDULE: ${CLEANUP_SCHEDULE:-}
@@ -147,6 +148,7 @@ services:
       SECRET_KEY: ${SECRET_KEY}
       FLASK_ENV: ${FLASK_ENV:-production}
       MAX_WORKERS: ${MAX_WORKERS:-10}  # Parallel file scanning workers per task
+      FREEZE_DETECTION_ENABLED: ${FREEZE_DETECTION_ENABLED:-true}
 
       # Scan configuration (required for scheduler)
       SCAN_PATHS: ${SCAN_PATHS:-/media}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -54,6 +54,7 @@ All configuration is done via environment variables, either in `.env` file or di
 | `BATCH_SIZE` | `100` | Files per batch during discovery | 50-200 based on file sizes |
 | `MAX_OUTPUT_SIZE` | `10000` | Max output characters before rotation | 10000-50000 |
 | `OUTPUT_ROTATION_ENABLED` | `true` | Enable output truncation | `true` for large scans |
+| `FREEZE_DETECTION_ENABLED` | `true` | Enable video freeze detection (freezedetect + blackdetect) | `false` to skip and reduce scan time |
 
 **Performance Notes:**
 - `MAX_WORKERS` controls parallelism within each scan task

--- a/pixelprobe/api/scan_routes.py
+++ b/pixelprobe/api/scan_routes.py
@@ -614,6 +614,9 @@ def get_scan_status():
     # Use database values primarily, with service as fallback
     current_progress = state_dict.get('files_processed', service_status.get('current', 0))
     total_progress = state_dict.get('estimated_total', service_status.get('total', 0))
+    # Fallback: if estimated_total is 0 but phase_total has a value, use it
+    if total_progress == 0 and state_dict.get('phase_total', 0) > 0:
+        total_progress = state_dict.get('phase_total')
 
     # When scan is active, read real-time progress from Redis (much fresher than PostgreSQL)
     if scan_state and scan_state.is_active and scan_state.scan_id:

--- a/pixelprobe/api/scan_routes.py
+++ b/pixelprobe/api/scan_routes.py
@@ -10,7 +10,7 @@ from pixelprobe.models import db, ScanResult, ScanState
 from pixelprobe.constants import TERMINAL_SCAN_PHASES
 from pixelprobe.version import __version__
 from pixelprobe.auth import auth_required
-from pixelprobe.progress_utils import get_scan_progress_redis
+from pixelprobe.progress_utils import get_scan_progress_redis, clear_scan_progress_redis
 
 from pixelprobe.utils.security import (
     validate_file_path, validate_directory_path,
@@ -936,6 +936,11 @@ def force_cleanup_scan():
             scan.phase = 'crashed'
             scan.error_message = 'Force cleaned up by admin'
             scan.end_time = datetime.now(timezone.utc)
+            # Clear stale Redis progress to prevent new scans from reading old data
+            try:
+                clear_scan_progress_redis(scan.scan_id)
+            except Exception as redis_err:
+                logger.warning(f"Failed to clear Redis progress for {scan.scan_id}: {redis_err}")
             cleaned_count += 1
         
         # Also stop any thread-based scans

--- a/pixelprobe/config.py
+++ b/pixelprobe/config.py
@@ -71,6 +71,7 @@ class Config:
     BATCH_SIZE = int(os.getenv('BATCH_SIZE', '100'))
     MAX_OUTPUT_SIZE = int(os.getenv('MAX_OUTPUT_SIZE', '10000'))  # For output rotation
     OUTPUT_ROTATION_ENABLED = os.getenv('OUTPUT_ROTATION_ENABLED', 'true').lower() == 'true'
+    FREEZE_DETECTION_ENABLED = os.getenv('FREEZE_DETECTION_ENABLED', 'true').lower() == 'true'
     
     # P1 Celery task queue configuration (now implemented)
     # Celery 5.x requires lowercase config keys - keep both for compatibility

--- a/pixelprobe/media_checker.py
+++ b/pixelprobe/media_checker.py
@@ -1682,8 +1682,10 @@ class PixelProbe:
         """Detect frozen video frames using FFmpeg's freezedetect filter.
 
         A freeze is where the video picture stops changing while time (and audio)
-        continues.  Uses the lavfi freezedetect filter with a 2-second minimum
-        duration and -60 dB noise tolerance.
+        continues.  Uses the lavfi freezedetect filter with a 4-second minimum
+        duration and -40 dB noise tolerance.  Black frame sections detected by
+        blackdetect are used to filter false positives from scene transitions,
+        studio logos, and end credits.
 
         Returns (is_corrupted, corruption_details, scan_output).
         """
@@ -1704,7 +1706,7 @@ class PixelProbe:
                 '-v', 'info',
                 '-i', file_path,
                 '-an',
-                '-vf', 'freezedetect=n=-60dB:d=2,blackdetect=d=0.5:pix_th=0.10',
+                '-vf', 'freezedetect=n=-40dB:d=4,blackdetect=d=1.0:pic_th=0.98:pix_th=0.10',
                 '-f', 'null',
                 '-'
             ], capture_output=True, text=True, timeout=timeout_seconds)

--- a/pixelprobe/media_checker.py
+++ b/pixelprobe/media_checker.py
@@ -1411,13 +1411,12 @@ class PixelProbe:
                 corruption_details.extend(hevc_details)
                 scan_output.extend(hevc_output)
         
-        # Freeze detection - check for stuck frames (configurable via FREEZE_DETECTION_ENABLED)
+        # Freeze detection - check for stuck frames (warning only, not corruption)
         freeze_enabled = os.getenv('FREEZE_DETECTION_ENABLED', 'true').lower() == 'true'
         if freeze_enabled and duration and duration > 0:
-            freeze_corrupted, freeze_details, freeze_output = self._check_video_freeze(file_path, duration)
-            if freeze_corrupted:
-                is_corrupted = True
-                corruption_details.extend(freeze_details)
+            freeze_detected, freeze_details, freeze_output = self._check_video_freeze(file_path, duration)
+            if freeze_detected:
+                warning_details.extend(freeze_details)
                 scan_output.extend(freeze_output)
 
         # Return warning details as well
@@ -1682,15 +1681,15 @@ class PixelProbe:
         """Detect frozen video frames using FFmpeg's freezedetect filter.
 
         A freeze is where the video picture stops changing while time (and audio)
-        continues.  Uses the lavfi freezedetect filter with a 4-second minimum
-        duration and -40 dB noise tolerance.  Black frame sections detected by
+        continues.  Uses the lavfi freezedetect filter with a 5-second minimum
+        duration and -60 dB noise tolerance.  Black frame sections detected by
         blackdetect are used to filter false positives from scene transitions,
         studio logos, and end credits.
 
-        Returns (is_corrupted, corruption_details, scan_output).
+        Returns (has_warnings, warning_details, scan_output).
         """
-        corruption_details = []
-        is_corrupted = False
+        warning_details = []
+        has_warnings = False
         scan_output = []
 
         logger.info(f"Running freeze detection for {file_path}")
@@ -1706,7 +1705,7 @@ class PixelProbe:
                 '-v', 'info',
                 '-i', file_path,
                 '-an',
-                '-vf', 'freezedetect=n=-40dB:d=4,blackdetect=d=1.0:pic_th=0.98:pix_th=0.10',
+                '-vf', 'freezedetect=n=-60dB:d=5,blackdetect=d=1.0:pic_th=0.98:pix_th=0.10',
                 '-f', 'null',
                 '-'
             ], capture_output=True, text=True, timeout=timeout_seconds)
@@ -1785,15 +1784,15 @@ class PixelProbe:
                 freeze_events = filtered
 
             if freeze_events:
-                is_corrupted = True
+                has_warnings = True
                 total_frozen = sum(e.get('duration', 0) for e in freeze_events)
                 frozen_pct = total_frozen / duration * 100
 
                 summary = (
-                    f"Video freeze detected: {len(freeze_events)} event(s), "
+                    f"Video freeze warning: {len(freeze_events)} event(s), "
                     f"{total_frozen:.1f}s frozen ({frozen_pct:.1f}% of video)"
                 )
-                corruption_details.append(summary)
+                warning_details.append(summary)
                 scan_output.append(summary)
 
                 for i, event in enumerate(freeze_events[:10]):
@@ -1806,8 +1805,8 @@ class PixelProbe:
                 if len(freeze_events) > 10:
                     scan_output.append(f"  ... and {len(freeze_events) - 10} more freeze event(s)")
 
-                logger.warning(
-                    f"Freeze detected in {file_path}: {len(freeze_events)} event(s), "
+                logger.info(
+                    f"Freeze warning in {file_path}: {len(freeze_events)} event(s), "
                     f"{total_frozen:.1f}s total frozen"
                 )
             else:
@@ -1822,13 +1821,11 @@ class PixelProbe:
         except OSError as e:
             # OSError includes SIGBUS and other memory-related errors
             logger.error(f"Freeze detection process crashed for {file_path}: {str(e)}")
-            corruption_details.append(f"Freeze detection process crashed (possible memory error): {str(e)}")
-            is_corrupted = True
         except Exception as e:
             logger.debug(f"Freeze detection error for {file_path}: {str(e)}")
 
         scan_output.append("=== Freeze Detection Complete ===")
-        return is_corrupted, corruption_details, scan_output
+        return has_warnings, warning_details, scan_output
 
     def _enhanced_corruption_check(self, file_path, file_size_gb):
         """Enhanced multi-stage corruption detection for files that fail basic checks"""

--- a/pixelprobe/media_checker.py
+++ b/pixelprobe/media_checker.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import magic
 import logging
@@ -24,6 +25,11 @@ import threading
 from pixelprobe.utils.security import safe_subprocess_run, validate_file_path
 
 logger = logging.getLogger(__name__)
+
+# Pre-compiled patterns for parsing FFmpeg freezedetect filter output
+_RE_FREEZE_START = re.compile(r'freeze_start:\s*([\d.]+)')
+_RE_FREEZE_END = re.compile(r'freeze_end:\s*([\d.]+)')
+_RE_FREEZE_DURATION = re.compile(r'freeze_duration:\s*([\d.]+)')
 
 def get_default_filename_patterns():
     """Get default filename patterns to exclude"""
@@ -1400,9 +1406,18 @@ class PixelProbe:
                 corruption_details.extend(hevc_details)
                 scan_output.extend(hevc_output)
         
+        # Freeze detection - check for stuck frames (configurable via FREEZE_DETECTION_ENABLED)
+        freeze_enabled = os.getenv('FREEZE_DETECTION_ENABLED', 'true').lower() == 'true'
+        if freeze_enabled and duration and duration > 0:
+            freeze_corrupted, freeze_details, freeze_output = self._check_video_freeze(file_path, duration)
+            if freeze_corrupted:
+                is_corrupted = True
+                corruption_details.extend(freeze_details)
+                scan_output.extend(freeze_output)
+
         # Return warning details as well
         return is_corrupted, corruption_details, scan_tool, scan_output, warning_details
-    
+
     def _check_audio_corruption(self, file_path):
         """Check audio files for corruption using FFmpeg and format-specific tools"""
         corruption_details = []
@@ -1657,7 +1672,109 @@ class PixelProbe:
             logger.error(f"HEVC Main 10 check error for {file_path}: {str(e)}")
         
         return is_corrupted, corruption_details, hevc_output
-    
+
+    def _check_video_freeze(self, file_path, duration):
+        """Detect frozen video frames using FFmpeg's freezedetect filter.
+
+        A freeze is where the video picture stops changing while time (and audio)
+        continues.  Uses the lavfi freezedetect filter with a 2-second minimum
+        duration and -60 dB noise tolerance.
+
+        Returns (is_corrupted, corruption_details, scan_output).
+        """
+        corruption_details = []
+        is_corrupted = False
+        scan_output = []
+
+        logger.info(f"Running freeze detection for {file_path}")
+        scan_output.append("=== Freeze Detection Analysis ===")
+
+        # Timeout: 2x realtime for full decode, floor 60s, cap 7200s
+        timeout_seconds = max(60, min(int(duration * 2), 7200))
+
+        try:
+            result = safe_subprocess_run([
+                'ffmpeg',
+                '-nostdin',
+                '-v', 'info',
+                '-i', file_path,
+                '-an',
+                '-vf', 'freezedetect=n=-60dB:d=2',
+                '-f', 'null',
+                '-'
+            ], capture_output=True, text=True, timeout=timeout_seconds)
+
+            stderr = result.stderr or ''
+
+            freeze_events = []
+            current_event = {}
+
+            for line in stderr.split('\n'):
+                if 'freezedetect' not in line.lower():
+                    continue
+
+                start_match = _RE_FREEZE_START.search(line)
+                if start_match:
+                    current_event['start'] = float(start_match.group(1))
+
+                end_match = _RE_FREEZE_END.search(line)
+                if end_match:
+                    current_event['end'] = float(end_match.group(1))
+
+                dur_match = _RE_FREEZE_DURATION.search(line)
+                if dur_match:
+                    current_event['duration'] = float(dur_match.group(1))
+                    # freeze_duration is the last field emitted per event
+                    if 'start' in current_event:
+                        freeze_events.append(current_event)
+                    current_event = {}
+
+            if freeze_events:
+                is_corrupted = True
+                total_frozen = sum(e.get('duration', 0) for e in freeze_events)
+                frozen_pct = total_frozen / duration * 100
+
+                summary = (
+                    f"Video freeze detected: {len(freeze_events)} event(s), "
+                    f"{total_frozen:.1f}s frozen ({frozen_pct:.1f}% of video)"
+                )
+                corruption_details.append(summary)
+                scan_output.append(summary)
+
+                for i, event in enumerate(freeze_events[:10]):
+                    start = event.get('start', 0)
+                    end = event.get('end', 0)
+                    dur = event.get('duration', 0)
+                    scan_output.append(
+                        f"  Freeze #{i + 1}: {start:.1f}s - {end:.1f}s (duration: {dur:.1f}s)"
+                    )
+                if len(freeze_events) > 10:
+                    scan_output.append(f"  ... and {len(freeze_events) - 10} more freeze event(s)")
+
+                logger.warning(
+                    f"Freeze detected in {file_path}: {len(freeze_events)} event(s), "
+                    f"{total_frozen:.1f}s total frozen"
+                )
+            else:
+                scan_output.append("No freeze events detected")
+                logger.info(f"No freeze detected in {file_path}")
+
+        except subprocess.TimeoutExpired:
+            scan_output.append(f"Freeze detection timed out after {timeout_seconds}s")
+            logger.warning(f"Freeze detection timeout for {file_path} ({timeout_seconds}s)")
+        except FileNotFoundError:
+            logger.warning("FFmpeg not found, skipping freeze detection")
+        except OSError as e:
+            # OSError includes SIGBUS and other memory-related errors
+            logger.error(f"Freeze detection process crashed for {file_path}: {str(e)}")
+            corruption_details.append(f"Freeze detection process crashed (possible memory error): {str(e)}")
+            is_corrupted = True
+        except Exception as e:
+            logger.debug(f"Freeze detection error for {file_path}: {str(e)}")
+
+        scan_output.append("=== Freeze Detection Complete ===")
+        return is_corrupted, corruption_details, scan_output
+
     def _enhanced_corruption_check(self, file_path, file_size_gb):
         """Enhanced multi-stage corruption detection for files that fail basic checks"""
         corruption_details = []

--- a/pixelprobe/media_checker.py
+++ b/pixelprobe/media_checker.py
@@ -31,6 +31,11 @@ _RE_FREEZE_START = re.compile(r'freeze_start:\s*([\d.]+)')
 _RE_FREEZE_END = re.compile(r'freeze_end:\s*([\d.]+)')
 _RE_FREEZE_DURATION = re.compile(r'freeze_duration:\s*([\d.]+)')
 
+# Pre-compiled patterns for parsing FFmpeg blackdetect filter output
+_RE_BLACK_START = re.compile(r'black_start:\s*([\d.]+)')
+_RE_BLACK_END = re.compile(r'black_end:\s*([\d.]+)')
+_RE_BLACK_DURATION = re.compile(r'black_duration:\s*([\d.]+)')
+
 def get_default_filename_patterns():
     """Get default filename patterns to exclude"""
     return [
@@ -1699,7 +1704,7 @@ class PixelProbe:
                 '-v', 'info',
                 '-i', file_path,
                 '-an',
-                '-vf', 'freezedetect=n=-60dB:d=2',
+                '-vf', 'freezedetect=n=-60dB:d=2,blackdetect=d=0.5:pix_th=0.10',
                 '-f', 'null',
                 '-'
             ], capture_output=True, text=True, timeout=timeout_seconds)
@@ -1707,27 +1712,75 @@ class PixelProbe:
             stderr = result.stderr or ''
 
             freeze_events = []
-            current_event = {}
+            black_events = []
+            current_freeze = {}
+            current_black = {}
 
             for line in stderr.split('\n'):
-                if 'freezedetect' not in line.lower():
-                    continue
+                line_lower = line.lower()
 
-                start_match = _RE_FREEZE_START.search(line)
-                if start_match:
-                    current_event['start'] = float(start_match.group(1))
+                # Parse freezedetect events
+                if 'freezedetect' in line_lower:
+                    start_match = _RE_FREEZE_START.search(line)
+                    if start_match:
+                        current_freeze['start'] = float(start_match.group(1))
 
-                end_match = _RE_FREEZE_END.search(line)
-                if end_match:
-                    current_event['end'] = float(end_match.group(1))
+                    end_match = _RE_FREEZE_END.search(line)
+                    if end_match:
+                        current_freeze['end'] = float(end_match.group(1))
 
-                dur_match = _RE_FREEZE_DURATION.search(line)
-                if dur_match:
-                    current_event['duration'] = float(dur_match.group(1))
-                    # freeze_duration is the last field emitted per event
-                    if 'start' in current_event:
-                        freeze_events.append(current_event)
-                    current_event = {}
+                    dur_match = _RE_FREEZE_DURATION.search(line)
+                    if dur_match:
+                        current_freeze['duration'] = float(dur_match.group(1))
+                        # freeze_duration is the last field emitted per event
+                        if 'start' in current_freeze:
+                            freeze_events.append(current_freeze)
+                        current_freeze = {}
+
+                # Parse blackdetect events
+                elif 'blackdetect' in line_lower or 'black_start' in line_lower:
+                    bs = _RE_BLACK_START.search(line)
+                    if bs:
+                        current_black['start'] = float(bs.group(1))
+
+                    be = _RE_BLACK_END.search(line)
+                    if be:
+                        current_black['end'] = float(be.group(1))
+
+                    bd = _RE_BLACK_DURATION.search(line)
+                    if bd:
+                        current_black['duration'] = float(bd.group(1))
+                        if 'start' in current_black and 'end' in current_black:
+                            black_events.append(current_black)
+                        current_black = {}
+
+            # Filter out freeze events that overlap with black sections
+            # Real freezes stick on actual content, not black frames
+            if freeze_events and black_events:
+                total_before = len(freeze_events)
+                filtered = []
+                for freeze in freeze_events:
+                    f_start = freeze.get('start', 0)
+                    f_end = f_start + freeze.get('duration', 0)
+                    overlaps_black = False
+                    for black in black_events:
+                        b_start = black.get('start', 0)
+                        b_end = black.get('end', 0)
+                        if f_start < b_end and b_start < f_end:
+                            overlaps_black = True
+                            break
+                    if not overlaps_black:
+                        filtered.append(freeze)
+                removed = total_before - len(filtered)
+                if removed > 0:
+                    logger.info(
+                        f"Filtered {removed} of {total_before} freeze events "
+                        f"(black frame overlap) for {file_path}"
+                    )
+                    scan_output.append(
+                        f"Filtered {removed} of {total_before} freeze events (black frame false positives)"
+                    )
+                freeze_events = filtered
 
             if freeze_events:
                 is_corrupted = True

--- a/pixelprobe/progress_utils.py
+++ b/pixelprobe/progress_utils.py
@@ -255,3 +255,22 @@ def update_scan_progress_redis(scan_id, files_processed=0, estimated_total=0, ph
             logger.error(f"Failed to verify Redis data for {scan_id} - key might not exist!")
     except Exception as e:
         logger.error(f"Failed to update Redis progress: {e}")
+
+
+def clear_scan_progress_redis(scan_id):
+    """
+    Delete scan progress key from Redis.
+
+    Call this when recovering stuck scans or before starting a new scan
+    to prevent stale progress data from a previous run.
+    """
+    redis_client = get_redis_client()
+    if not redis_client:
+        return
+
+    progress_key = f"{_PROGRESS_KEY_PREFIX}:{scan_id}"
+    try:
+        redis_client.delete(progress_key)
+        logger.info(f"Cleared Redis progress key for scan {scan_id}")
+    except Exception as e:
+        logger.warning(f"Failed to clear Redis progress for scan {scan_id}: {e}")

--- a/pixelprobe/services/scan_service.py
+++ b/pixelprobe/services/scan_service.py
@@ -226,6 +226,13 @@ class ScanService:
         scan_state_id = scan_state.id
         scan_id = scan_state.scan_id
 
+        # Clear stale Redis progress from a previous scan with this ID
+        try:
+            from pixelprobe.progress_utils import clear_scan_progress_redis
+            clear_scan_progress_redis(scan_id)
+        except Exception as e:
+            logger.debug(f"Could not clear stale Redis progress for {scan_id}: {e}")
+
         # Start UI progress worker task if using Celery
         try:
             from pixelprobe.tasks import ui_progress_update_task
@@ -710,6 +717,11 @@ class ScanService:
             logger.info("Running scan synchronously for Celery task")
             try:
                 run_scan()
+                # run_scan() uses a nested app_context with its own db.session,
+                # so the outer session may have stale cached objects (including
+                # is_active=True from before _mark_scan_completed ran).
+                # Expire all to force fresh reads from PostgreSQL.
+                db.session.expire_all()
                 # Get final scan state for results
                 final_scan_state = db.session.get(ScanState, scan_state_id)
                 if final_scan_state:
@@ -1755,6 +1767,10 @@ class ScanService:
             }
         )
         db.session.commit()
+        # Expire all cached ORM objects so subsequent queries/commits
+        # read the updated state from PostgreSQL instead of writing
+        # stale is_active=True back from the identity map
+        db.session.expire_all()
 
     def _create_scan_report(self, scan_state: ScanState, scan_type: str = 'full_scan'):
         """Create a scan report from the completed scan state"""

--- a/pixelprobe/services/scan_service.py
+++ b/pixelprobe/services/scan_service.py
@@ -622,6 +622,18 @@ class ScanService:
                     db.session.commit()
                     # Force flush to ensure changes are written immediately
                     db.session.flush()
+
+                    # Ensure Redis has the correct total immediately after phase transition
+                    # Prevents "0 of 0" display while chunk counting runs
+                    if hasattr(self, 'update_scan_progress_redis') and self.update_scan_progress_redis and self.scan_id:
+                        self.update_scan_progress_redis(
+                            self.scan_id,
+                            files_processed=0,
+                            estimated_total=total_scan_files,
+                            phase='scanning',
+                            current_file=''
+                        )
+
                     logger.info(f"Scan state transitioned to 'scanning' phase "
                                f"with {total_scan_files} files")
                     

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.2'
+_DEFAULT_VERSION = '2.6.3'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.4'
+_DEFAULT_VERSION = '2.6.5'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.3'
+_DEFAULT_VERSION = '2.6.4'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.5'
+_DEFAULT_VERSION = '2.6.7'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.7'
+_DEFAULT_VERSION = '2.6.8'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/tests/test_media_checker.py
+++ b/tests/test_media_checker.py
@@ -4,6 +4,7 @@ Tests for PixelProbe media checker core functionality
 
 import pytest
 import os
+import subprocess
 import time
 import threading
 from unittest.mock import Mock, patch, MagicMock
@@ -402,3 +403,199 @@ class TestMediaChecker:
         # Scan output should be captured
         assert 'scan_output' in result
         # Output might be None for valid files or contain FFmpeg output
+
+
+class TestVideoFreezeDetection:
+    """Test video freeze detection via FFmpeg freezedetect filter"""
+
+    def _make_freezedetect_stderr(self, events):
+        """Build fake FFmpeg stderr containing freezedetect log lines.
+
+        Args:
+            events: list of (start, end, duration) tuples
+        """
+        lines = []
+        for start, end, duration in events:
+            lines.append(
+                f"[freezedetect @ 0x1234] lavfi.freezedetect.freeze_start: {start}"
+            )
+            lines.append(
+                f"[freezedetect @ 0x1234] lavfi.freezedetect.freeze_end: {end}"
+            )
+            lines.append(
+                f"[freezedetect @ 0x1234] lavfi.freezedetect.freeze_duration: {duration}"
+            )
+        return "\n".join(lines)
+
+    @patch('subprocess.run')
+    def test_video_freeze_detection(self, mock_run):
+        """Freeze events are detected and marked as corruption"""
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stderr = self._make_freezedetect_stderr([
+            (10.0, 15.0, 5.0),
+            (45.5, 50.0, 4.5),
+        ])
+        mock_result.stdout = ''
+        mock_run.return_value = mock_result
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+            '/fake/video.mp4', duration=120.0
+        )
+
+        assert is_corrupted is True
+        assert len(corruption_details) == 1
+        assert '2 event(s)' in corruption_details[0]
+        assert '9.5s frozen' in corruption_details[0]
+        assert '7.9%' in corruption_details[0]
+        # Scan output should contain per-event detail
+        assert any('Freeze #1' in line for line in scan_output)
+        assert any('Freeze #2' in line for line in scan_output)
+
+    @patch('subprocess.run')
+    def test_video_no_freeze(self, mock_run):
+        """Clean video produces no corruption"""
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stderr = 'frame=1200 fps=60 q=-0.0 Lsize=N/A time=00:00:40.00'
+        mock_result.stdout = ''
+        mock_run.return_value = mock_result
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+            '/fake/clean.mp4', duration=40.0
+        )
+
+        assert is_corrupted is False
+        assert corruption_details == []
+        assert any('No freeze events' in line for line in scan_output)
+
+    @patch('subprocess.run')
+    def test_video_freeze_timeout(self, mock_run):
+        """Timeout during freeze detection is handled gracefully"""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd='ffmpeg', timeout=60)
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+            '/fake/big.mp4', duration=30.0
+        )
+
+        assert is_corrupted is False
+        assert corruption_details == []
+        assert any('timed out' in line for line in scan_output)
+
+    @patch('os.path.getsize')
+    @patch('os.path.exists')
+    @patch('subprocess.run')
+    @patch('ffmpeg.probe')
+    def test_video_freeze_integrated_in_corruption_check(
+        self, mock_probe, mock_run, mock_exists, mock_getsize
+    ):
+        """Freeze detection results propagate through _check_video_corruption"""
+        mock_exists.return_value = True
+        mock_getsize.return_value = 1024 * 1024
+
+        mock_probe.return_value = {
+            'streams': [{
+                'codec_type': 'video',
+                'codec_name': 'h264',
+                'profile': 'High',
+                'pix_fmt': 'yuv420p',
+                'duration': '60.0'
+            }],
+            'format': {
+                'duration': '60.0'
+            }
+        }
+
+        # All subprocess calls return clean except freeze detection
+        def subprocess_side_effect(cmd, *args, **kwargs):
+            result = Mock()
+            result.returncode = 0
+            result.stdout = ''
+            # Detect the freezedetect call by checking for the filter arg
+            if any('freezedetect' in str(arg) for arg in cmd):
+                result.stderr = self._make_freezedetect_stderr([(5.0, 10.0, 5.0)])
+            else:
+                result.stderr = ''
+            return result
+
+        mock_run.side_effect = subprocess_side_effect
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, scan_tool, scan_output, warning_details = (
+            checker._check_video_corruption('/fake/freeze_video.mp4')
+        )
+
+        assert is_corrupted is True
+        assert any('Video freeze detected' in d for d in corruption_details)
+        assert any('Freeze #1' in line for line in scan_output)
+
+    @patch('subprocess.run')
+    def test_video_freeze_incomplete_event_dropped(self, mock_run):
+        """Incomplete freeze event (video ends mid-freeze) is silently dropped"""
+        # freeze_start emitted but freeze_duration never comes
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stderr = (
+            "[freezedetect @ 0x1234] lavfi.freezedetect.freeze_start: 55.0\n"
+        )
+        mock_result.stdout = ''
+        mock_run.return_value = mock_result
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+            '/fake/cutoff.mp4', duration=60.0
+        )
+
+        assert is_corrupted is False
+        assert corruption_details == []
+        assert any('No freeze events' in line for line in scan_output)
+
+    @patch.dict('os.environ', {'FREEZE_DETECTION_ENABLED': 'false'})
+    @patch('os.path.getsize')
+    @patch('os.path.exists')
+    @patch('subprocess.run')
+    @patch('ffmpeg.probe')
+    def test_freeze_detection_disabled_via_env(
+        self, mock_probe, mock_run, mock_exists, mock_getsize
+    ):
+        """Freeze detection is skipped when FREEZE_DETECTION_ENABLED=false"""
+        mock_exists.return_value = True
+        mock_getsize.return_value = 1024 * 1024
+
+        mock_probe.return_value = {
+            'streams': [{
+                'codec_type': 'video',
+                'codec_name': 'h264',
+                'profile': 'High',
+                'pix_fmt': 'yuv420p',
+                'duration': '60.0'
+            }],
+            'format': {
+                'duration': '60.0'
+            }
+        }
+
+        # Return freezedetect output -- but it should never be reached
+        def subprocess_side_effect(cmd, *args, **kwargs):
+            result = Mock()
+            result.returncode = 0
+            result.stdout = ''
+            if any('freezedetect' in str(arg) for arg in cmd):
+                result.stderr = self._make_freezedetect_stderr([(5.0, 10.0, 5.0)])
+            else:
+                result.stderr = ''
+            return result
+
+        mock_run.side_effect = subprocess_side_effect
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, scan_tool, scan_output, warning_details = (
+            checker._check_video_corruption('/fake/freeze_disabled.mp4')
+        )
+
+        # Should NOT be corrupted -- freeze detection was skipped
+        assert not any('Video freeze detected' in d for d in corruption_details)
+        assert not any('Freeze #' in line for line in scan_output)

--- a/tests/test_media_checker.py
+++ b/tests/test_media_checker.py
@@ -427,6 +427,19 @@ class TestVideoFreezeDetection:
             )
         return "\n".join(lines)
 
+    def _make_blackdetect_stderr(self, events):
+        """Build fake FFmpeg stderr containing blackdetect log lines.
+
+        Args:
+            events: list of (start, end, duration) tuples
+        """
+        lines = []
+        for start, end, duration in events:
+            lines.append(
+                f"[blackdetect @ 0x5678] black_start:{start} black_end:{end} black_duration:{duration}"
+            )
+        return "\n".join(lines)
+
     @patch('subprocess.run')
     def test_video_freeze_detection(self, mock_run):
         """Freeze events are detected and marked as corruption"""
@@ -599,3 +612,58 @@ class TestVideoFreezeDetection:
         # Should NOT be corrupted -- freeze detection was skipped
         assert not any('Video freeze detected' in d for d in corruption_details)
         assert not any('Freeze #' in line for line in scan_output)
+
+    @patch('subprocess.run')
+    def test_video_freeze_black_frame_filtered(self, mock_run):
+        """Freeze events overlapping black sections are filtered as false positives"""
+        # Freeze at 0-3s and 100-105s, black at 0-4s and 99-106s
+        # Both freezes overlap black -- should be filtered out entirely
+        freeze_stderr = self._make_freezedetect_stderr([
+            (0.0, 3.0, 3.0),
+            (100.0, 105.0, 5.0),
+        ])
+        black_stderr = self._make_blackdetect_stderr([
+            (0.0, 4.0, 4.0),
+            (99.0, 106.0, 7.0),
+        ])
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stderr = freeze_stderr + "\n" + black_stderr
+        mock_result.stdout = ''
+        mock_run.return_value = mock_result
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+            '/fake/transitions.mp4', duration=120.0
+        )
+
+        assert is_corrupted is False
+        assert corruption_details == []
+        assert any('Filtered 2 of 2' in line for line in scan_output)
+
+    @patch('subprocess.run')
+    def test_video_freeze_real_freeze_not_filtered(self, mock_run):
+        """Freeze on actual content (no black overlap) is still flagged"""
+        # Freeze at 50-55s on real content, black only at 0-2s (opening)
+        freeze_stderr = self._make_freezedetect_stderr([
+            (0.0, 2.0, 2.0),    # overlaps black -- filtered
+            (50.0, 55.0, 5.0),  # no black overlap -- kept
+        ])
+        black_stderr = self._make_blackdetect_stderr([
+            (0.0, 2.5, 2.5),
+        ])
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_result.stderr = freeze_stderr + "\n" + black_stderr
+        mock_result.stdout = ''
+        mock_run.return_value = mock_result
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+            '/fake/real_freeze.mp4', duration=120.0
+        )
+
+        assert is_corrupted is True
+        assert len(corruption_details) == 1
+        assert '1 event(s)' in corruption_details[0]
+        assert any('Filtered 1 of 2' in line for line in scan_output)

--- a/tests/test_media_checker.py
+++ b/tests/test_media_checker.py
@@ -442,7 +442,7 @@ class TestVideoFreezeDetection:
 
     @patch('subprocess.run')
     def test_video_freeze_detection(self, mock_run):
-        """Freeze events are detected and marked as corruption"""
+        """Freeze events are detected and returned as warnings"""
         mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stderr = self._make_freezedetect_stderr([
@@ -453,22 +453,21 @@ class TestVideoFreezeDetection:
         mock_run.return_value = mock_result
 
         checker = PixelProbe()
-        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+        has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/video.mp4', duration=120.0
         )
 
-        assert is_corrupted is True
-        assert len(corruption_details) == 1
-        assert '2 event(s)' in corruption_details[0]
-        assert '9.5s frozen' in corruption_details[0]
-        assert '7.9%' in corruption_details[0]
-        # Scan output should contain per-event detail
+        assert has_warnings is True
+        assert len(warning_details) == 1
+        assert '2 event(s)' in warning_details[0]
+        assert '9.5s frozen' in warning_details[0]
+        assert '7.9%' in warning_details[0]
         assert any('Freeze #1' in line for line in scan_output)
         assert any('Freeze #2' in line for line in scan_output)
 
     @patch('subprocess.run')
     def test_video_no_freeze(self, mock_run):
-        """Clean video produces no corruption"""
+        """Clean video produces no warnings"""
         mock_result = Mock()
         mock_result.returncode = 0
         mock_result.stderr = 'frame=1200 fps=60 q=-0.0 Lsize=N/A time=00:00:40.00'
@@ -476,12 +475,12 @@ class TestVideoFreezeDetection:
         mock_run.return_value = mock_result
 
         checker = PixelProbe()
-        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+        has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/clean.mp4', duration=40.0
         )
 
-        assert is_corrupted is False
-        assert corruption_details == []
+        assert has_warnings is False
+        assert warning_details == []
         assert any('No freeze events' in line for line in scan_output)
 
     @patch('subprocess.run')
@@ -490,12 +489,12 @@ class TestVideoFreezeDetection:
         mock_run.side_effect = subprocess.TimeoutExpired(cmd='ffmpeg', timeout=60)
 
         checker = PixelProbe()
-        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+        has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/big.mp4', duration=30.0
         )
 
-        assert is_corrupted is False
-        assert corruption_details == []
+        assert has_warnings is False
+        assert warning_details == []
         assert any('timed out' in line for line in scan_output)
 
     @patch('os.path.getsize')
@@ -541,8 +540,10 @@ class TestVideoFreezeDetection:
             checker._check_video_corruption('/fake/freeze_video.mp4')
         )
 
-        assert is_corrupted is True
-        assert any('Video freeze detected' in d for d in corruption_details)
+        # Freeze detection produces warnings, not corruption
+        assert is_corrupted is False
+        assert not any('Video freeze' in d for d in corruption_details)
+        assert any('Video freeze warning' in w for w in warning_details)
         assert any('Freeze #1' in line for line in scan_output)
 
     @patch('subprocess.run')
@@ -558,12 +559,12 @@ class TestVideoFreezeDetection:
         mock_run.return_value = mock_result
 
         checker = PixelProbe()
-        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+        has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/cutoff.mp4', duration=60.0
         )
 
-        assert is_corrupted is False
-        assert corruption_details == []
+        assert has_warnings is False
+        assert warning_details == []
         assert any('No freeze events' in line for line in scan_output)
 
     @patch.dict('os.environ', {'FREEZE_DETECTION_ENABLED': 'false'})
@@ -633,12 +634,12 @@ class TestVideoFreezeDetection:
         mock_run.return_value = mock_result
 
         checker = PixelProbe()
-        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+        has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/transitions.mp4', duration=120.0
         )
 
-        assert is_corrupted is False
-        assert corruption_details == []
+        assert has_warnings is False
+        assert warning_details == []
         assert any('Filtered 2 of 2' in line for line in scan_output)
 
     @patch('subprocess.run')
@@ -659,11 +660,11 @@ class TestVideoFreezeDetection:
         mock_run.return_value = mock_result
 
         checker = PixelProbe()
-        is_corrupted, corruption_details, scan_output = checker._check_video_freeze(
+        has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/real_freeze.mp4', duration=120.0
         )
 
-        assert is_corrupted is True
-        assert len(corruption_details) == 1
-        assert '1 event(s)' in corruption_details[0]
+        assert has_warnings is True
+        assert len(warning_details) == 1
+        assert '1 event(s)' in warning_details[0]
         assert any('Filtered 1 of 2' in line for line in scan_output)


### PR DESCRIPTION
## Summary
- Video freeze detection using FFmpeg freezedetect filter with black frame false positive filtering
- Freeze events reported as warnings (not corruption) -- files stay healthy
- Tuned to n=-60dB:d=5 to eliminate false positives on animation and live-action
- Configurable via FREEZE_DETECTION_ENABLED env var (default: true)
- Fix "0 of 0 files" progress display during scanning phase
- Fix scan stuck as active after completion (ORM identity map + stale Redis)

## Version
2.6.8

## Test plan
- [x] 8 freeze detection tests passing
- [x] Scan completion tests passing
- [x] Docker image built and pushed (2.6.8 and latest)