### PR TITLE
Queue-on-conflict retry for skipped scheduled scans + log handler session recovery (v2.6.39)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.6.39] - 2026-04-20
+
+### Fixed
+
+- **Scheduled scans silently dropped when another scan is running**: When a scheduled scan's cron fire landed while a prior scan was still in progress, `MediaScheduler` logged `Scheduled scan {id} skipped - another scan is already running` and returned. APScheduler consumed the cron fire, so the next run advanced to the following cron interval (a weekly Sunday cleanup could go missing for an entire week). Added a queue-on-conflict retry that schedules a one-shot date-trigger retry `SCHEDULE_RETRY_DELAY_MINUTES` later (default 10), up to `SCHEDULE_RETRY_MAX_COUNT` times (default 6), and clears the retry state as soon as a scan actually starts. Applies to `_run_scheduled_scan`, `_run_periodic_scan`, and the env-var `_run_cleanup` HTTP 409 path. Retry state is kept in process memory; if the worker restarts while a retry is pending, the retry is lost and the schedule will fire again on its next regular cron.
+- **Database log handler stuck after a flush failure**: `DatabaseLogHandler._flush_batch` attempted `db.session.rollback()` inside a silent try/except; if the rollback itself failed (stale connection, broken pipe), the scoped session stayed in `InvalidRequestError: Please rollback() fully before proceeding` state for the life of the writer thread, producing a flood of `[log_handler] Failed to flush N log entries to DB` lines. Added `db.session.remove()` after the rollback so the next flush starts with a fresh scoped session, and rate-limited the stderr report to once per 60s so recurring failures still surface instead of being logged exactly once at startup. Also moved `import sys` to the top of the file.
+
+---
+
 ## [2.6.38] - 2026-04-06
 
 ### Fixed

--- a/pixelprobe/scheduler.py
+++ b/pixelprobe/scheduler.py
@@ -16,6 +16,12 @@ from pixelprobe.services.healthcheck_service import HealthcheckService
 logger = logging.getLogger(__name__)
 
 class MediaScheduler:
+    # Defaults for queue-on-conflict retry when a scheduled scan fires while
+    # another scan is still running. Up to MAX_COUNT retries spaced
+    # DELAY_MINUTES apart; after that we give up until the next cron fire.
+    DEFAULT_RETRY_DELAY_MINUTES = 10
+    DEFAULT_RETRY_MAX_COUNT = 6
+
     def __init__(self, app=None):
         self.scheduler = BackgroundScheduler()
         self.app = app
@@ -24,8 +30,79 @@ class MediaScheduler:
         self.excluded_paths = []
         self.excluded_extensions = []
 
+        self.pending_retries: Dict[str, int] = {}
+        self._retry_lock = threading.Lock()
+        self.retry_delay_minutes = self._load_positive_int_env(
+            'SCHEDULE_RETRY_DELAY_MINUTES', self.DEFAULT_RETRY_DELAY_MINUTES, min_value=1
+        )
+        self.retry_max_count = self._load_positive_int_env(
+            'SCHEDULE_RETRY_MAX_COUNT', self.DEFAULT_RETRY_MAX_COUNT, min_value=0
+        )
+
         # Load exclusions from environment
         self._load_exclusions()
+
+    @staticmethod
+    def _load_positive_int_env(var_name: str, default: int, min_value: int) -> int:
+        raw = os.environ.get(var_name)
+        if raw is None:
+            return default
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"Invalid {var_name}={raw!r}; falling back to default {default}"
+            )
+            return default
+        return max(min_value, value)
+
+    def _queue_conflict_retry(self, retry_key: str, retry_func, retry_args, reason: str):
+        """Queue a one-shot retry when a scheduled scan's cron fire is skipped.
+
+        APScheduler consumes the original cron fire when the guard trips, so
+        without a retry the schedule is silently dropped until its next regular
+        fire (e.g. a weekly cleanup would go missing for an entire week).
+        """
+        run_date = datetime.now(timezone.utc) + timedelta(minutes=self.retry_delay_minutes)
+        # Hold the lock across add_job so the counter can't drift if two callers
+        # race on the same retry_key. add_job on the default MemoryJobStore is
+        # in-process and cheap, so the critical section stays short.
+        with self._retry_lock:
+            count = self.pending_retries.get(retry_key, 0)
+            if count >= self.retry_max_count:
+                logger.warning(
+                    f"{retry_key} skipped ({reason}); already retried "
+                    f"{count} times, giving up until next cron fire"
+                )
+                self.pending_retries.pop(retry_key, None)
+                return
+            count += 1
+            job_id = f"{retry_key}_retry_{count}"
+            try:
+                self.scheduler.add_job(
+                    func=retry_func,
+                    args=list(retry_args),
+                    trigger='date',
+                    run_date=run_date,
+                    id=job_id,
+                    max_instances=1,
+                    replace_existing=True,
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to queue retry job {job_id}: {e}", exc_info=True
+                )
+                return
+            self.pending_retries[retry_key] = count
+
+        logger.warning(
+            f"{retry_key} skipped ({reason}); queued retry "
+            f"#{count}/{self.retry_max_count} at {run_date.isoformat()}"
+        )
+
+    def _clear_pending_retry(self, retry_key: str):
+        with self._retry_lock:
+            self.pending_retries.pop(retry_key, None)
 
     def _filter_excluded_paths(self, scan_paths):
         """Filter out excluded paths and return the remaining ones."""
@@ -311,14 +388,19 @@ class MediaScheduler:
         if not self.scan_lock.acquire(blocking=False):
             logger.warning("Periodic scan already in progress, skipping")
             return
-            
+
         try:
             with self.app.app_context():
                 # Check if ANY scan is already running before proceeding
                 scan_state = ScanState.get_or_create()
                 if scan_state.is_active and scan_state.phase not in TERMINAL_SCAN_PHASES:
-                    logger.warning(f"Periodic scan skipped - another scan is already running (phase: {scan_state.phase})")
+                    self._queue_conflict_retry(
+                        'periodic', self._run_periodic_scan, (),
+                        f"phase={scan_state.phase}"
+                    )
                     return
+
+                self._clear_pending_retry('periodic')
 
                 from pixelprobe.utils.helpers import get_configured_scan_paths
                 scan_paths = get_configured_scan_paths()
@@ -349,6 +431,7 @@ class MediaScheduler:
             
     def _run_scheduled_scan(self, schedule_id: int):
         """Run a scheduled scan via HTTP self-call to avoid Flask context issues"""
+        retry_key = f"schedule_{schedule_id}"
         if not self.scan_lock.acquire(blocking=False):
             logger.warning(f"Scheduled scan {schedule_id} already in progress, skipping")
             return
@@ -358,8 +441,13 @@ class MediaScheduler:
                 # Check if ANY scan is already running before proceeding
                 scan_state = ScanState.get_or_create()
                 if scan_state.is_active and scan_state.phase not in TERMINAL_SCAN_PHASES:
-                    logger.warning(f"Scheduled scan {schedule_id} skipped - another scan is already running (phase: {scan_state.phase})")
+                    self._queue_conflict_retry(
+                        retry_key, self._run_scheduled_scan, (schedule_id,),
+                        f"phase={scan_state.phase}"
+                    )
                     return
+
+                self._clear_pending_retry(retry_key)
 
                 schedule = db.session.get(ScanSchedule, schedule_id)
                 if not schedule or not schedule.is_active:
@@ -468,17 +556,21 @@ class MediaScheduler:
                 }
                 
                 try:
-                    response = requests.post(f'{base_url}/api/cleanup-orphaned', 
+                    response = requests.post(f'{base_url}/api/cleanup-orphaned',
                                           headers=headers,
                                           timeout=60)
-                    
+
                     if response.status_code == 200:
                         logger.info("Cleanup task started successfully")
+                        self._clear_pending_retry('default_cleanup')
                     elif response.status_code == 409:
-                        logger.warning("Cleanup skipped - another scan/cleanup is already running")
+                        self._queue_conflict_retry(
+                            'default_cleanup', self._run_cleanup, (),
+                            "api returned 409"
+                        )
                     else:
                         logger.error(f"Cleanup API call failed: {response.status_code} - {response.text}")
-                        
+
                 except requests.exceptions.RequestException as e:
                     logger.error(f"Failed to call API for cleanup: {e}")
                 

--- a/pixelprobe/utils/log_handler.py
+++ b/pixelprobe/utils/log_handler.py
@@ -6,10 +6,11 @@ on database writes. Records are batch-inserted periodically.
 """
 
 import logging
-import threading
-import traceback
-import time
 import queue
+import sys
+import threading
+import time
+import traceback
 from datetime import datetime, timezone
 
 from pixelprobe.utils.log_context import current_scan_id, current_celery_task_id
@@ -30,6 +31,7 @@ class DatabaseLogHandler(logging.Handler):
     QUEUE_MAX_SIZE = 10000
     BATCH_SIZE = 100
     FLUSH_INTERVAL = 1.0  # seconds
+    FLUSH_ERROR_LOG_INTERVAL = 60.0  # seconds between repeated stderr messages
 
     def __init__(self, app):
         super().__init__()
@@ -39,6 +41,7 @@ class DatabaseLogHandler(logging.Handler):
             name.strip() for name in DEFAULT_LOG_EXCLUDE_LOGGERS.split(',') if name.strip()
         }
         self._running = True
+        self._flush_error_logged_at = 0.0
 
         # Start background writer thread
         self._writer_thread = threading.Thread(
@@ -152,15 +155,27 @@ class DatabaseLogHandler(logging.Handler):
         try:
             db.session.bulk_insert_mappings(LogEntry, batch)
             db.session.commit()
-            self._flush_error_logged = False
+            self._flush_error_logged_at = 0.0
         except Exception as e:
-            # Log the first failure to stderr (not via logging to avoid recursion)
-            if not getattr(self, '_flush_error_logged', False):
-                import sys
-                print(f"[log_handler] Failed to flush {len(batch)} log entries to DB: {e}", file=sys.stderr)
-                self._flush_error_logged = True
+            # Rate-limit stderr reports to once per FLUSH_ERROR_LOG_INTERVAL so
+            # recurring failures still surface without flooding logs.
+            now = time.monotonic()
+            if now - self._flush_error_logged_at > self.FLUSH_ERROR_LOG_INTERVAL:
+                print(
+                    f"[log_handler] Failed to flush {len(batch)} log entries to DB: {e}",
+                    file=sys.stderr,
+                )
+                self._flush_error_logged_at = now
             try:
                 db.session.rollback()
+            except Exception:
+                pass
+            # Discard the scoped session so the next flush starts fresh. Protects
+            # against rollback() silently failing on a broken connection, which
+            # would otherwise leave db.session stuck in "rollback() fully before
+            # proceeding" state for the life of the writer thread.
+            try:
+                db.session.remove()
             except Exception:
                 pass
 

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.38'
+_DEFAULT_VERSION = '2.6.39'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -303,6 +303,72 @@ class TestDatabaseLogHandler:
         finally:
             handler.shutdown()
 
+    def test_flush_failure_resets_session_and_throttles_log(self, app, monkeypatch):
+        """On flush failure the handler must rollback+remove the session so the
+        next flush starts clean, and rate-limit stderr output."""
+        from pixelprobe.utils.log_handler import DatabaseLogHandler
+        from pixelprobe.models import db
+
+        handler = DatabaseLogHandler(app)
+        try:
+            with app.app_context():
+                remove_calls = {'n': 0}
+                rollback_calls = {'n': 0}
+                original_remove = db.session.remove
+                original_rollback = db.session.rollback
+
+                def counting_remove(*a, **kw):
+                    remove_calls['n'] += 1
+                    return original_remove(*a, **kw)
+
+                def counting_rollback(*a, **kw):
+                    rollback_calls['n'] += 1
+                    return original_rollback(*a, **kw)
+
+                monkeypatch.setattr(db.session, 'remove', counting_remove)
+                monkeypatch.setattr(db.session, 'rollback', counting_rollback)
+
+                def boom(*args, **kwargs):
+                    raise RuntimeError('simulated bulk insert failure')
+
+                monkeypatch.setattr(db.session, 'bulk_insert_mappings', boom)
+
+                batch = [{
+                    'scan_id': None,
+                    'celery_task_id': None,
+                    'timestamp': None,
+                    'level': 'ERROR',
+                    'logger_name': 'pixelprobe.test',
+                    'message': 'boom',
+                    'traceback': None,
+                }]
+
+                first_logged_at = handler._flush_error_logged_at
+                handler._flush_batch(batch)
+                assert rollback_calls['n'] == 1
+                assert remove_calls['n'] == 1
+                assert handler._flush_error_logged_at > first_logged_at
+
+                # Second flush within the throttle window: no new stderr emission,
+                # but rollback+remove must still run to recover the session.
+                previous_logged_at = handler._flush_error_logged_at
+                handler._flush_batch(batch)
+                assert rollback_calls['n'] == 2
+                assert remove_calls['n'] == 2
+                assert handler._flush_error_logged_at == previous_logged_at
+
+                # Rewind past the throttle window: a new stderr line must emit
+                # so operators still see recurring failures.
+                handler._flush_error_logged_at = (
+                    previous_logged_at - handler.FLUSH_ERROR_LOG_INTERVAL - 1.0
+                )
+                handler._flush_batch(batch)
+                assert rollback_calls['n'] == 3
+                assert remove_calls['n'] == 3
+                assert handler._flush_error_logged_at > previous_logged_at
+        finally:
+            handler.shutdown()
+
 
 # ---------------------------------------------------------------------------
 # Log API route tests

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,7 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
+
 from pixelprobe.scheduler import MediaScheduler
 from pixelprobe.models import db, ScanSchedule
 
@@ -216,7 +219,78 @@ class TestMediaScheduler:
             
             # Call update_schedules
             scheduler.update_schedules()
-            
+
             # The job should be removed and re-added
             # Since we don't have the actual schedule loading logic in test,
             # at least verify the method runs without error
+
+
+class TestQueueConflictRetry:
+    """Test that skipped scheduled scans get a one-shot retry queued."""
+
+    @pytest.fixture
+    def scheduler(self, app):
+        scheduler = MediaScheduler()
+        scheduler.init_app(app)
+        yield scheduler
+        scheduler.shutdown()
+
+    def test_queues_date_trigger_retry(self, scheduler):
+        def noop(schedule_id):
+            return None
+
+        scheduler._queue_conflict_retry('schedule_42', noop, (42,), 'phase=scanning')
+
+        assert scheduler.pending_retries['schedule_42'] == 1
+
+        job = scheduler.scheduler.get_job('schedule_42_retry_1')
+        assert job is not None
+        expected = datetime.now(timezone.utc) + timedelta(minutes=scheduler.retry_delay_minutes)
+        assert abs((job.next_run_time - expected).total_seconds()) < 30
+
+    def test_respects_max_count(self, scheduler):
+        def noop(schedule_id):
+            return None
+
+        scheduler.retry_max_count = 2
+        scheduler._queue_conflict_retry('schedule_99', noop, (99,), 'phase=scanning')
+        scheduler._queue_conflict_retry('schedule_99', noop, (99,), 'phase=scanning')
+        # Third call hits the cap and should drop the pending entry.
+        scheduler._queue_conflict_retry('schedule_99', noop, (99,), 'phase=scanning')
+
+        assert 'schedule_99' not in scheduler.pending_retries
+        assert scheduler.scheduler.get_job('schedule_99_retry_3') is None
+
+    def test_clear_pending_retry_removes_entry(self, scheduler):
+        def noop():
+            return None
+
+        scheduler._queue_conflict_retry('periodic', noop, (), 'phase=scanning')
+        assert 'periodic' in scheduler.pending_retries
+
+        scheduler._clear_pending_retry('periodic')
+        assert 'periodic' not in scheduler.pending_retries
+
+    def test_add_job_failure_does_not_consume_slot(self, scheduler, monkeypatch):
+        """If APScheduler fails to enqueue the retry job the counter must not
+        advance, otherwise transient failures would burn through retry_max_count
+        without a single retry actually running."""
+        def noop(schedule_id):
+            return None
+
+        def broken_add_job(*args, **kwargs):
+            raise RuntimeError('simulated APScheduler failure')
+
+        monkeypatch.setattr(scheduler.scheduler, 'add_job', broken_add_job)
+
+        scheduler._queue_conflict_retry('schedule_77', noop, (77,), 'phase=scanning')
+
+        assert 'schedule_77' not in scheduler.pending_retries
+
+    def test_invalid_env_var_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv('SCHEDULE_RETRY_DELAY_MINUTES', 'not-a-number')
+        monkeypatch.setenv('SCHEDULE_RETRY_MAX_COUNT', '-5')
+
+        scheduler = MediaScheduler()
+        assert scheduler.retry_delay_minutes == MediaScheduler.DEFAULT_RETRY_DELAY_MINUTES
+        assert scheduler.retry_max_count == 0  # clamped via min_value=0


### PR DESCRIPTION
## Summary

- **Scheduled scans no longer silently dropped on overlap**: `MediaScheduler` now queues a one-shot date-trigger retry when a cron fire is skipped because another scan is running. Configurable via `SCHEDULE_RETRY_DELAY_MINUTES` (default 10) and `SCHEDULE_RETRY_MAX_COUNT` (default 6). Retry state clears as soon as a scan actually starts.
- **`DatabaseLogHandler` recovers from a failed flush**: adds `db.session.remove()` after rollback so the scoped session isn't stuck in "rollback() fully before proceeding" state for the life of the writer thread; rate-limits the stderr report to once per 60s.
- Retry state is in-process; if the worker restarts while a retry is pending, the retry is lost and the next cron fire will pick things up.

## Version

`2.6.39` (bumped from `2.6.38`).

## Test plan

- [x] Full pytest suite green (319 passed, 8 skipped, 0 failed)
- [x] Added 3 new tests for `_queue_conflict_retry` (queue, cap, clear, add_job-failure rollback, malformed env var) and 1 expanded test for `DatabaseLogHandler` flush recovery (rollback+remove path, throttle window expiry)
- [x] Docker image `2.6.39` built for `linux/amd64` and pushed to Docker Hub (also tagged `latest`)
- [ ] Deploy via Portainer webhook and confirm `/api/version` reports `2.6.39`
- [ ] After next overlap event, confirm `queued retry` warning appears and the retry fires
- [ ] Confirm `Failed to flush` stderr lines stop flooding