### PR TITLE
Scheduler retry window 24h + urllib3/base-image security bumps (v2.6.43)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.6.43] - 2026-05-25
+
+### Security
+
+- **Bump `urllib3` floor to `>=2.7.0`** to resolve CVE-2026-44431 and CVE-2026-44432 (HTTP response decompression denial-of-service). HIGH severity. Pinned in `requirements.txt` because it's transitive through `requests`; `requests==2.33.0` still permits the vulnerable 2.6.x line otherwise.
+- **`apt-get upgrade` added to the Ubuntu 24.04 base layer** so the image picks up security patches the base image hasn't been rebuilt with, including the linux-libc-dev kernel-header CVEs (CVE-2026-22984, CVE-2026-31431) that Trivy flagged at HIGH.
+
+### Fixed
+
+- **Weekly schedule silently dropped when a long-running AddNew scan was concurrent**. On 2026-05-25 the Sunday 02:00 EDT cleanup (`schedule_10`) was skipped six times in a row and then abandoned because the 6-hour AddNew scan that started at 00:00 took 3h 5m (vs the typical <35 min) and was still in `phase=scanning` at 03:00 -- the queue-on-conflict retry window introduced in v2.6.39 was capped at `DEFAULT_RETRY_MAX_COUNT=6 * DEFAULT_RETRY_DELAY_MINUTES=10 min = 60 min`. The conflicting scan finished four minutes after the cap expired, so the weekly schedule was lost until the next cron fire one week later. Raised `DEFAULT_RETRY_MAX_COUNT` from 6 to 144, giving a 24-hour retry window that safely covers any realistic scan duration. Per-schedule retry counters (`pending_retries[f"schedule_{schedule_id}"]`) remain isolated, and the env override `SCHEDULE_RETRY_MAX_COUNT` is unchanged for operators who want tighter behavior.
+
 ## [2.6.42] - 2026-05-01
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # - ImageMagick 6.9.13 (newer than 22.04's 6.9.11)
 # - Python 3.12 by default
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y \
     # Python and pip
     python3 \

--- a/pixelprobe/scheduler.py
+++ b/pixelprobe/scheduler.py
@@ -20,7 +20,7 @@ class MediaScheduler:
     # another scan is still running. Up to MAX_COUNT retries spaced
     # DELAY_MINUTES apart; after that we give up until the next cron fire.
     DEFAULT_RETRY_DELAY_MINUTES = 10
-    DEFAULT_RETRY_MAX_COUNT = 6
+    DEFAULT_RETRY_MAX_COUNT = 144
 
     def __init__(self, app=None):
         self.scheduler = BackgroundScheduler()

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.42'
+_DEFAULT_VERSION = '2.6.43'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ gunicorn==23.0.0
 pytz==2023.3
 APScheduler==3.11.0
 requests==2.33.0
+urllib3>=2.7.0  # transitive via requests; pinned to resolve CVE-2026-44431 / CVE-2026-44432
 reportlab==4.2.5
 psutil==7.0.0
 PyYAML==6.0.2


### PR DESCRIPTION
## Summary

- **Scheduler fix**: Raise `DEFAULT_RETRY_MAX_COUNT` from 6 to 144 so the queue-on-conflict retry covers a 24-hour window instead of 60 min. Closes the gap that silently dropped `schedule_10` (weekly Sunday 02:00) on 2026-05-25, when the concurrent 6-hour AddNew scan ran 3h 5m (vs the usual <35 min) and finished 4 min after the prior retry cap expired.
- **Security (HIGH)**: Pin `urllib3>=2.7.0` in `requirements.txt` to resolve CVE-2026-44431 / CVE-2026-44432 (HTTP response decompression DoS). Transitive via `requests==2.33.0`.
- **Security (HIGH)**: Add `apt-get upgrade` to the Ubuntu 24.04 base layer so the image picks up patches for CVE-2026-22984 and CVE-2026-31431 (linux-libc-dev).

## Version

`2.6.43` (in `pixelprobe/version.py`).

## Test plan

- [x] `pytest tests/test_scheduler.py` -- 15/15 pass, including all 5 in `TestQueueConflictRetry`
- [x] Full `pytest tests/` -- 335 passed, 8 skipped
- [x] `docker build --platform=linux/amd64 -t ttlequals0/pixelprobe:2.6.43 .`
- [x] `trivy image --severity HIGH,CRITICAL ttlequals0/pixelprobe:2.6.43` -- 0 findings
- [x] `docker push ttlequals0/pixelprobe:2.6.43` -- digest `sha256:c079281e6f66caca4f40b31150555a65977f6fb2a9b08dbe1d8a1acded9898a4`
- [ ] CodeQL / GitHub Actions checks pass
- [ ] Post-deploy: verify `/api/version` reports `2.6.43`
- [ ] Verify next weekly schedule fires even when an AddNew scan is concurrent