### PR TITLE
Fix Celery worker crash on high-throughput integrity scans (v2.6.48)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.6.48] - 2026-06-01
+
+### Fixed (integrity scan reliability at scale: 1.2M files up to ~55GB)
+
+- **Celery worker no longer crashes mid-scan with `Unrecoverable error: AssertionError()`.** Under a high-throughput integrity scan (1M+ tiny immich thumbnails hashing in sub-millisecond bursts) the worker event stream flooded the kombu event-loop hub and tripped an assertion in `hub.fire_timers`, wedging the worker so every subsequent task was abandoned at the timeout and the scan got stuck. Disabled Celery task events (`worker_send_task_events` / `task_send_sent_event`; PixelProbe reads progress from the DB, not Celery events) and launched the worker with `--without-gossip --without-mingle --without-heartbeat` to remove the worker-to-worker event-loop timers (unused with a single worker on a Redis broker) that fed the crash.
+- **Reduced the fork storm on tiny-file scans.** Raised the default `--max-tasks-per-child` from 50 to 1000 (env `CELERY_MAX_TASKS_PER_CHILD`); 50 sub-millisecond hashes recycled a child in well under a second, producing tens of thousands of forks that hammered the pool. Per-child memory is still capped at 2GB for heavy/large-file tasks.
+- **Worker now auto-restarts after an unrecoverable Celery shutdown.** `celery_worker.py` exits non-zero when `worker_main` returns unexpectedly, so `restart: unless-stopped` brings the container back instead of leaving a dead/idle worker.
+- **The largest files are no longer skipped.** The integrity per-task timeout default was raised from 30 minutes to 3 hours (env `INTEGRITY_TASK_TIMEOUT_SECS`). The hash task reads the whole file; a ~55GB sequential read on slow/contended storage can exceed 30 minutes, which previously abandoned (skipped) the biggest files mid-hash.
+
 ## [2.6.47] - 2026-06-01
 
 ### Fixed (reliability hardening - phase 4: observability + cleanup)

--- a/celery_worker.py
+++ b/celery_worker.py
@@ -50,22 +50,48 @@ def main():
     logger.info(f"Log Level: {log_level}")
     logger.info(f"Concurrency: {concurrency}")
     
-    # Start the worker
+    # max-tasks-per-child is env-overridable. Default raised from 50 to 1000: an
+    # integrity scan over 1M+ tiny thumbnails completes 50 sub-ms hashes in well
+    # under a second, so a low value caused a fork storm (tens of thousands of
+    # child respawns) that hammered the prefork pool and event loop. Memory is
+    # still bounded by --max-memory-per-child for heavy/large-file media tasks.
     try:
-        celery_app.worker_main([
+        max_tasks_per_child = int(os.getenv('CELERY_MAX_TASKS_PER_CHILD', '1000'))
+    except (TypeError, ValueError):
+        max_tasks_per_child = 1000
+
+    # Start the worker.
+    # --without-gossip/--without-mingle/--without-heartbeat remove worker-to-worker
+    # event-loop timers (unused with a single worker on a Redis broker) which,
+    # together with task events, trip the kombu hub.fire_timers AssertionError
+    # under high-throughput scans.
+    try:
+        rc = celery_app.worker_main([
             'worker',
             '--loglevel', log_level.lower(),
             '--concurrency', str(concurrency),
             '--queues', 'pixelprobe',
             '--hostname', f'pixelprobe-worker@%h',
-            '--max-tasks-per-child', '50',
+            '--max-tasks-per-child', str(max_tasks_per_child),
             '--max-memory-per-child', '2000000',  # 2GB limit per child for media processing
+            '--without-gossip',
+            '--without-mingle',
+            '--without-heartbeat',
         ])
     except KeyboardInterrupt:
         logger.info("Worker stopped by user")
+        return
     except Exception as e:
         logger.error(f"Worker failed: {e}")
         sys.exit(1)
+
+    # Propagate Celery's own exit code: 0 for a clean (warm/SIGTERM) shutdown,
+    # non-zero for an unrecoverable error. Exiting non-zero lets the container's
+    # restart policy bring a crashed worker back, while a clean shutdown exits 0
+    # (no false restart / misleading error on a normal stop).
+    if rc:
+        logger.error(f"Celery worker exited with code {rc}; exiting non-zero to trigger container restart")
+    sys.exit(rc or 0)
 
 
 if __name__ == '__main__':

--- a/pixelprobe/celery_config.py
+++ b/pixelprobe/celery_config.py
@@ -76,10 +76,15 @@ def create_celery(app=None):
         # Task deduplication to prevent multiple workers from picking up same retry
         'task_track_started': True,  # Track when tasks actually start execution
         'task_ignore_result': False,  # Store results for monitoring
-        
-        # Monitoring
-        'worker_send_task_events': True,
-        'task_send_sent_event': True,
+
+        # Monitoring task events are DISABLED. Under a high-throughput scan (e.g.
+        # 1M+ tiny immich thumbnails hashing in sub-millisecond bursts), the
+        # event stream floods the kombu event-loop hub and trips an
+        # "Unrecoverable error: AssertionError()" in hub.fire_timers that wedges
+        # the worker. PixelProbe's UI reads progress from the DB (/api/*-status),
+        # not Celery events, so disabling these costs nothing here.
+        'worker_send_task_events': False,
+        'task_send_sent_event': False,
         
         # Result backend settings
         'result_expires': 86400,  # Results expire after 24 hours

--- a/pixelprobe/services/maintenance_service.py
+++ b/pixelprobe/services/maintenance_service.py
@@ -28,8 +28,14 @@ logger = logging.getLogger(__name__)
 # many seconds are considered orphaned (worker died, broker lost the message,
 # etc.) and dropped from the active set so the producer loop can keep moving.
 # Override via the INTEGRITY_TASK_TIMEOUT_SECS environment variable.
+#
+# Default is 3h (was 30m): the hash task reads the WHOLE file, and PixelProbe
+# scans files up to ~55GB. On slow/contended storage a 55GB sequential read can
+# exceed 30 minutes, so a too-low timeout abandons (skips) the very largest files
+# mid-hash. 3h covers ~55GB down to ~5MB/s; with the 5000-slot concurrency cap a
+# few genuinely-dead tasks holding slots this long is harmless.
 INTEGRITY_TASK_TIMEOUT_SECS = int(
-    os.environ.get('INTEGRITY_TASK_TIMEOUT_SECS', 1800)
+    os.environ.get('INTEGRITY_TASK_TIMEOUT_SECS', 10800)
 )
 
 

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.47'
+_DEFAULT_VERSION = '2.6.48'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/tests/unit/test_maintenance_service.py
+++ b/tests/unit/test_maintenance_service.py
@@ -21,10 +21,12 @@ class TestIntegrityTaskTimeoutConfig:
         os.environ.pop('INTEGRITY_TASK_TIMEOUT_SECS', None)
         importlib.reload(maintenance_service)
 
-    def test_default_is_thirty_minutes(self):
+    def test_default_is_three_hours(self):
+        # Raised from 30m to 3h so a ~55GB sequential hash on slow storage is not
+        # abandoned mid-read.
         os.environ.pop('INTEGRITY_TASK_TIMEOUT_SECS', None)
         importlib.reload(maintenance_service)
-        assert maintenance_service.INTEGRITY_TASK_TIMEOUT_SECS == 1800
+        assert maintenance_service.INTEGRITY_TASK_TIMEOUT_SECS == 10800
 
     def test_overrides_via_environment(self):
         os.environ['INTEGRITY_TASK_TIMEOUT_SECS'] = '120'


### PR DESCRIPTION
## Summary

Production integrity scan (1.2M files, up to ~55GB each) got stuck: the Celery worker crashed with `Unrecoverable error: AssertionError()` deep in `kombu hub.fire_timers` during the flood of sub-millisecond thumbnail hashes, then hung without exiting, so every task was abandoned at the timeout.

## Changes

- Disable Celery task events (`worker_send_task_events` / `task_send_sent_event`) -- they fed the kombu event-loop hub that crashed. PixelProbe reads progress from the DB (`/api/*-status`), not Celery events.
- Launch the worker with `--without-gossip --without-mingle --without-heartbeat` (worker-to-worker timers, unused with a single worker on a Redis broker).
- Raise default `--max-tasks-per-child` 50 -> 1000 (`CELERY_MAX_TASKS_PER_CHILD`) to stop the fork storm on tiny-file hashes.
- Propagate the worker exit code so an unrecoverable shutdown trips the container restart policy instead of leaving a hung worker.
- Raise `INTEGRITY_TASK_TIMEOUT_SECS` default 1800 -> 10800 so a ~55GB whole-file hash on slow storage is not abandoned mid-read.

## Version

2.6.48

## Test plan

- [x] Full suite: 357 passed, 8 skipped
- [x] Review pass; one real bug fixed (exit-code propagation vs blanket exit 1)
- [x] linux/amd64 image built, Trivy clean (0 HIGH/CRITICAL), pushed
- [x] Deployed and verified live: worker came up with task events OFF, reached `ready`, and is processing `calculate_file_hash_task` with no AssertionError