### PR TITLE
Scheduler lock rework, UTC session pin, IPv6 bind support (v2.6.65)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,14 @@ MEDIA_PATH=/path/to/your/media
 # Performance tuning
 # MAX_WORKERS: parallel file scanning threads per task (default: 10)
 MAX_WORKERS=10
+
+# Scheduler ownership (default: true). In multi-container deployments set
+# false on the web container so only the Celery worker runs the scheduler.
+# SCHEDULER_ENABLED=true
+
+# Gunicorn listen address; comma-separated list allowed (default: 0.0.0.0:5000)
+# For IPv6/dual-stack (e.g. rootless podman) use: GUNICORN_BIND=[::]:5000
+# GUNICORN_BIND=0.0.0.0:5000
 # BATCH_SIZE: files per database batch commit (default: 100)
 BATCH_SIZE=100
 

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ CLAUDE.md
 CLAUDE.MD
 audit_reports/
 .playwright-mcp/
+# Claude superpowers plugin artifacts
+superpowers/

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.6.65] - 2026-07-15
+
+### Fixed
+
+- **Active scans no longer get falsely marked crashed (#65).** Two defects compounded. First, the app writes timezone-aware UTC datetimes into naive TIMESTAMP columns and reads them back assuming UTC, but PostgreSQL converts aware values to the session timezone before dropping the offset - on a server with a non-UTC default timezone every scan timestamp was stored as local wall time, making a running scan look hours stale and tripping the stuck-scan checks within seconds of starting. The database session timezone is now pinned to UTC at connect time. Second, the stuck-scan checks treated the orchestrator task's SUCCESS state as "task lost" - but the orchestrator finishes as soon as chunk tasks are queued, so a chunked scan was declared dead while its chunks were actively scanning. Both the scheduler sweep's task-gone branch and the scan-launch check now consider a scan alive while any of its chunks are pending or processing and the scan has updated within the last 30 minutes; the 30-minute no-progress hard timeout stays as the backstop so a worker that died mid-chunk cannot block scans forever. The same fix also revived the sweep's Celery task check, which had been silently disabled since it was added: it imported `safe_check_task_state` from a module that never contained it and swallowed the ImportError. Symptom: progress bar disappears and the scan button resets mid-scan while file counts keep climbing, with `/api/scan-status` reporting `phase=crashed`.
+- **Scheduler lock contention between web and Celery containers (#64).** Every process importing the app raced for the Redis scheduler lock, and lock identity was hostname:pid - unsafe in podman pods, where containers share a hostname while pids collide across pid namespaces. A collision let one container force-steal a live lock ("self-lock"), and the heartbeat then overwrote the key unconditionally, so two schedulers could run at once. The lock value now carries a per-process uuid, acquisition is strictly SET NX (dead holders recover via the 60s TTL, never by force-steal), and the heartbeat refreshes the TTL with an atomic compare-and-expire that cannot clobber another holder. The standby retry loop also retries indefinitely instead of giving up after 5 minutes, so failover keeps working long after boot.
+
+### Added
+
+- **`SCHEDULER_ENABLED` environment variable (#64).** Set `false` on a container to keep it out of scheduler lock arbitration entirely (default `true`). docker-compose.yml now sets it to `false` on the web service so only the Celery worker runs the scheduler, matching the documented intent.
+- **`GUNICORN_BIND` environment variable for IPv6 / dual-stack deployments (#63).** Gunicorn settings moved from the hardcoded Dockerfile CMD into `gunicorn.conf.py`. `GUNICORN_BIND` accepts a comma-separated list of listen addresses (default unchanged: `0.0.0.0:5000`); rootless podman users wanting dual-stack can set `GUNICORN_BIND=[::]:5000`. `GUNICORN_WORKERS`, `GUNICORN_TIMEOUT`, and `GUNICORN_LOG_LEVEL` are also overridable now.
+
 ## [2.6.64] - 2026-07-09
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,4 +161,5 @@ ENV FLASK_ENV=production
 # Don't set APP_VERSION here - let version.py be the single source of truth
 # The app will read the version from version.py directly
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "300", "--access-logfile", "-", "--error-logfile", "-", "--log-level", "info", "app:app"]
+# Bind/workers/timeout/logging live in gunicorn.conf.py (GUNICORN_* env overrides)
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ PixelProbe uses environment variables for all configuration. Copy `.env.example`
 - `EXCLUDED_PATHS` - Paths to ignore during scanning
 - `EXCLUDED_EXTENSIONS` - File extensions to ignore
 - `FREEZE_DETECTION_ENABLED` - Enable video freeze detection (default: `true`). Set to `false` to skip freeze detection and reduce scan time for large video libraries
+- `SCHEDULER_ENABLED` - Whether this container may run the scan scheduler (default: `true`). In multi-container deployments set `false` on the web container so only the Celery worker competes for the scheduler lock
+- `GUNICORN_BIND` - Gunicorn listen address, accepts a comma-separated list (default: `0.0.0.0:5000`). For IPv6/dual-stack (e.g. rootless podman) set `[::]:5000`
 
 See `.env.example` for complete configuration options with examples.
 

--- a/app.py
+++ b/app.py
@@ -125,6 +125,12 @@ if os.environ.get('DATABASE_URL'):
     logger.warning("DATABASE_URL is deprecated since v2.2.0. Use POSTGRES_HOST, POSTGRES_USER, etc. instead.")
     logger.warning("DATABASE_URL support will be removed in v2.3.0.")
     app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
+    if not app.config['SQLALCHEMY_DATABASE_URI'].startswith('postgresql'):
+        # PostgreSQL-specific connect_args (timezone pin, connect_timeout)
+        # are invalid keyword arguments for other drivers' connect()
+        engine_options = app.config['SQLALCHEMY_ENGINE_OPTIONS'].copy()
+        engine_options['connect_args'] = {}
+        app.config['SQLALCHEMY_ENGINE_OPTIONS'] = engine_options
 
 # Initialize extensions
 db.init_app(app)
@@ -611,6 +617,7 @@ with app.app_context():
 
     try:
         # Initialize scheduler with distributed lock coordination
+        # (honors SCHEDULER_ENABLED -- see scheduler_lock.scheduler_enabled)
         from pixelprobe.scheduler_lock import initialize_scheduler_with_lock
         initialize_scheduler_with_lock(app, scheduler)
     except Exception as e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,11 +63,15 @@ services:
 
   # PixelProbe application
   pixelprobe:
-    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.6.57}
+    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.6.65}
     container_name: pixelprobe-app
     environment:
       # Security
       SECRET_KEY: ${SECRET_KEY}
+
+      # Scheduler runs in celery-worker; keep the web container out of the
+      # scheduler lock entirely (set to "true" only in single-container setups)
+      SCHEDULER_ENABLED: "false"
       
       # PostgreSQL database configuration
       POSTGRES_HOST: postgres
@@ -131,7 +135,7 @@ services:
 
   # P1 Celery Worker for distributed task processing
   celery-worker:
-    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.6.57}
+    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.6.65}
     container_name: pixelprobe-celery-worker
     command: python celery_worker.py
     environment:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -45,6 +45,11 @@ All configuration is done via environment variables, either in `.env` file or di
 | `SCAN_PATHS` | `/media` | Comma-separated paths to scan inside container |
 | `TZ` | `UTC` | Timezone for timestamps (e.g., `America/New_York`) |
 | `PORT` | `5000` | Web interface port |
+| `GUNICORN_BIND` | `0.0.0.0:5000` | Gunicorn listen address; accepts a comma-separated list for multiple sockets. For dual-stack IPv4+IPv6 (e.g. rootless podman) set `[::]:5000` -- one IPv6 wildcard also accepts IPv4 when the kernel keeps `net.ipv6.bindv6only=0` (the Linux default). Do not list both `0.0.0.0:5000` and `[::]:5000` on such kernels; the second bind fails with `EADDRINUSE`. |
+| `GUNICORN_WORKERS` | `4` | Gunicorn worker process count |
+| `GUNICORN_TIMEOUT` | `300` | Gunicorn per-request timeout in seconds |
+| `GUNICORN_LOG_LEVEL` | `info` | Gunicorn log level |
+| `SCHEDULER_ENABLED` | `true` | Whether this process may run the scan scheduler. In multi-container deployments set `false` on the web container so only the Celery worker competes for the scheduler lock. Leave `true` in single-container setups. |
 
 ### Performance Variables
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,26 @@
+"""Gunicorn configuration.
+
+Defaults match the previous hardcoded Dockerfile CMD, so existing deployments
+behave as before. GUNICORN_BIND accepts a comma-separated list of addresses;
+see docs/CONFIGURATION.md for the dual-stack (IPv6) guidance and caveats.
+"""
+
+import os
+
+
+def _env_int(name, default):
+    # Blank values (e.g. compose passthrough of an unset var) and garbage
+    # fall back to the default instead of crash-looping the container.
+    try:
+        return int(os.environ.get(name) or default)
+    except ValueError:
+        return default
+
+
+_env_bind = os.environ.get("GUNICORN_BIND", "")
+bind = [b.strip() for b in _env_bind.split(",") if b.strip()] or ["0.0.0.0:5000"]
+workers = _env_int("GUNICORN_WORKERS", 4)
+timeout = _env_int("GUNICORN_TIMEOUT", 300)
+accesslog = "-"
+errorlog = "-"
+loglevel = os.environ.get("GUNICORN_LOG_LEVEL") or "info"

--- a/pixelprobe/api/scan_routes.py
+++ b/pixelprobe/api/scan_routes.py
@@ -24,7 +24,7 @@ from pixelprobe.api.scan_launch import launch_directory_scan
 logger = logging.getLogger(__name__)
 
 
-from pixelprobe.utils.celery_utils import check_celery_available
+from pixelprobe.utils.celery_utils import check_celery_available, safe_check_task_state
 
 
 _SCAN_ALREADY_RUNNING_RESPONSE = {
@@ -51,48 +51,6 @@ def _scan_conflict_response(error):
     return _SCAN_CONFLICT_FALLBACK_RESPONSE, 409
 
 
-def safe_check_task_state(celery_task_id, app, max_retries=3, base_delay=0.5):
-    """
-    Safely check Celery task state with retry logic for Redis connection errors.
-
-    v2.5.54: Added to protect AsyncResult.state access from Redis connection crashes.
-
-    Args:
-        celery_task_id: Celery task ID
-        app: Celery application instance
-        max_retries: Number of retry attempts
-        base_delay: Base delay between retries in seconds
-
-    Returns:
-        Task state string or None if unable to determine state
-    """
-    import redis
-    import time
-    from celery.result import AsyncResult
-    from pixelprobe.progress_utils import reset_redis_pool
-
-    for attempt in range(max_retries):
-        try:
-            result = AsyncResult(celery_task_id, app=app)
-            return result.state
-        except (redis.ConnectionError, redis.TimeoutError, ConnectionResetError, AttributeError) as e:
-            # Reset connection pool on first failure
-            if attempt == 0:
-                reset_redis_pool()
-
-            if attempt < max_retries - 1:
-                delay = base_delay * (attempt + 1)
-                logger.warning(f"Redis error checking task state (attempt {attempt + 1}/{max_retries}), retrying in {delay}s: {type(e).__name__}: {e}")
-                time.sleep(delay)
-            else:
-                logger.error(f"Failed to check task state after {max_retries} attempts: {type(e).__name__}: {e}")
-                return None
-        except Exception as e:
-            logger.error(f"Unexpected error checking task state: {type(e).__name__}: {e}")
-            return None
-    return None
-
-
 # Timezone handling via utility module
 
 scan_bp = Blueprint('scan', __name__, url_prefix='/api')
@@ -104,11 +62,25 @@ def is_scan_running():
     # Check thread-based scans
     if current_app.scan_service.is_scan_running():
         return True
-    
+
     # Check database for active Celery-based scans
     try:
         active_scan = ScanState.query.filter_by(is_active=True).first()
         if active_scan and active_scan.phase not in TERMINAL_SCAN_PHASES:
+            # Live chunk tasks mean the scan is running no matter what the
+            # orchestrator task's Celery state says (see ScanChunk.has_active)
+            # -- unless nothing has updated for 30+ minutes (the scheduler
+            # sweep's hard threshold). The stale case falls through to the
+            # crash-marking below, so a dead worker's orphaned chunk rows
+            # cannot block scan launches forever.
+            if ScanChunk.has_active(active_scan.scan_id):
+                last_activity = active_scan.last_update or active_scan.start_time
+                if last_activity:
+                    if last_activity.tzinfo is None:
+                        last_activity = last_activity.replace(tzinfo=timezone.utc)
+                    if datetime.now(timezone.utc) - last_activity <= timedelta(minutes=30):
+                        return True
+
             # Check if scan is stale (no progress update)
             from datetime import datetime, timezone, timedelta
             
@@ -149,7 +121,7 @@ def is_scan_running():
                             return True  # Task is still running, just slow
                         elif task_state is not None:
                             logger.warning(f"Celery task {active_scan.celery_task_id} is not active (state: {task_state})")
-                    
+
                     # Mark as crashed and allow new scan
                     active_scan.is_active = False
                     active_scan.phase = 'crashed'

--- a/pixelprobe/config.py
+++ b/pixelprobe/config.py
@@ -7,6 +7,17 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Pin the PostgreSQL session timezone to UTC. The app stores aware-UTC
+# datetimes in TIMESTAMP WITHOUT TIME ZONE columns and reads them back
+# assuming UTC; PostgreSQL converts aware values to the SESSION timezone
+# before dropping the offset, so a non-UTC server default (e.g. TZ set on the
+# postgres container) silently stores local wall time and makes every scan
+# look hours stale to the stuck-scan checks (issue #65). The class-level
+# connect_args carry this option; init_app overrides merge into them rather
+# than rebuild, so the pin is never dropped. The worker engine in
+# media_checker.py carries it too.
+PG_SESSION_TZ_UTC = '-c timezone=UTC'
+
 
 class Config:
     """Base configuration - PostgreSQL only"""
@@ -41,7 +52,7 @@ class Config:
         'max_overflow': int(os.getenv('DB_MAX_OVERFLOW', '10')),
         'pool_timeout': 30,
         'echo': os.getenv('DATABASE_ECHO', 'false').lower() == 'true',
-        'connect_args': {}  # Will be populated in init_app if needed
+        'connect_args': {'options': PG_SESSION_TZ_UTC}
     }
     
     # Build basic PostgreSQL connection string (will be refined in init_app)
@@ -133,11 +144,13 @@ class Config:
             # Use the complete URI for both Flask and PixelProbe compatibility
             app.config['SQLALCHEMY_DATABASE_URI'] = complete_uri
             
-            # Update engine options for Flask app optimizations
+            # Update engine options for Flask app optimizations. Merge into the
+            # class-level connect_args so the UTC timezone pin is never dropped.
             engine_options = app.config['SQLALCHEMY_ENGINE_OPTIONS'].copy()
             engine_options['connect_args'] = {
+                **engine_options.get('connect_args', {}),
                 'connect_timeout': 10,
-                'application_name': 'pixelprobe'
+                'application_name': 'pixelprobe',
             }
             app.config['SQLALCHEMY_ENGINE_OPTIONS'] = engine_options
             logger.debug(f"Complete database URI configured for {cls.POSTGRES_USER}@{cls.POSTGRES_HOST}:{cls.POSTGRES_PORT}/{cls.POSTGRES_DB}")
@@ -201,7 +214,7 @@ class TestingConfig(Config):
         'pool_size': 5,
         'max_overflow': 0,
         'pool_timeout': 10,
-        'connect_args': {}  # Will be populated in init_app
+        'connect_args': {'options': PG_SESSION_TZ_UTC}
     }
     
     # Disable output rotation in tests
@@ -221,13 +234,14 @@ class TestingConfig(Config):
         if cls.POSTGRES_PASSWORD:
             engine_options = app.config['SQLALCHEMY_ENGINE_OPTIONS'].copy()
             engine_options['connect_args'] = {
+                **engine_options.get('connect_args', {}),
                 'user': cls.POSTGRES_USER,
                 'password': cls.POSTGRES_PASSWORD,
                 'host': cls.POSTGRES_HOST,
                 'port': int(cls.POSTGRES_PORT),
                 'dbname': cls.POSTGRES_DB,  # Use test database
                 'connect_timeout': 5,
-                'application_name': 'pixelprobe_test'
+                'application_name': 'pixelprobe_test',
             }
             app.config['SQLALCHEMY_ENGINE_OPTIONS'] = engine_options
 

--- a/pixelprobe/media_checker.py
+++ b/pixelprobe/media_checker.py
@@ -166,6 +166,7 @@ class PixelProbe:
                 from sqlalchemy import create_engine
                 from sqlalchemy.orm import sessionmaker
                 from sqlalchemy.pool import StaticPool
+                from pixelprobe.config import PG_SESSION_TZ_UTC
                 # Thread-local instances use StaticPool with single persistent connection
                 # This avoids both connection pool exhaustion AND NullPool's concurrent operation errors
                 if self.database_path.startswith('postgresql://'):
@@ -178,7 +179,10 @@ class PixelProbe:
                         poolclass=StaticPool,  # Single persistent connection per engine
                         connect_args={
                             'connect_timeout': 10,
-                            'application_name': 'pixelprobe_worker'
+                            'application_name': 'pixelprobe_worker',
+                            # Same UTC session pin as the Flask engine (issue #65):
+                            # this engine writes scan_date/creation_date/last_modified
+                            'options': PG_SESSION_TZ_UTC
                         }
                     )
                 else:

--- a/pixelprobe/models.py
+++ b/pixelprobe/models.py
@@ -709,6 +709,23 @@ class ScanChunk(db.Model):
     # Add composite unique constraint
     __table_args__ = (db.UniqueConstraint('scan_id', 'chunk_id', name='uq_scan_chunks_scan_chunk'),)
 
+    ACTIVE_STATUSES = ('pending', 'processing')
+
+    @classmethod
+    def has_active(cls, scan_id):
+        """Whether any chunk tasks of a scan are still pending or processing.
+
+        Chunked scans outlive their orchestrator task: the orchestrator returns
+        as soon as chunk tasks are queued, so its Celery state (SUCCESS) says
+        nothing about whether the scan is still running (issue #65).
+        """
+        return db.session.query(
+            cls.query.filter(
+                cls.scan_id == scan_id,
+                cls.status.in_(cls.ACTIVE_STATUSES)
+            ).exists()
+        ).scalar()
+
     @staticmethod
     def fcp_directory_path(first_path, last_path):
         """Encode an FCP path-range for directory_path (the UI parses this format)."""

--- a/pixelprobe/scheduler.py
+++ b/pixelprobe/scheduler.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
-from pixelprobe.models import db, ScanSchedule, ScanResult, ScanState, HealthcheckConfig, ScanReport
+from pixelprobe.models import db, ScanSchedule, ScanResult, ScanState, ScanChunk, HealthcheckConfig, ScanReport
 from pixelprobe.constants import SCAN_PHASES, TERMINAL_SCAN_PHASES
 from pixelprobe.services.scan_engine import maybe_finalize_scan
 from pixelprobe.utils.paths import is_path_under
@@ -800,6 +800,28 @@ class MediaScheduler:
         except Exception as e:
             logger.error(f"Schedule database sync failed: {e}")
             
+    def _celery_task_gone(self, scan):
+        """Whether the scan's Celery work is definitively gone.
+
+        A lost/crashed Celery task with a stale last_update is a definitive
+        crash indicator -- but the orchestrator task alone is not authoritative:
+        it returns (SUCCESS) as soon as chunk tasks are queued, so the scan
+        counts as alive while any chunks remain active (issue #65).
+        """
+        if not scan.celery_task_id:
+            return False
+        try:
+            from pixelprobe.utils.celery_utils import check_celery_available, safe_check_task_state
+            from flask import current_app
+            if ScanChunk.has_active(scan.scan_id):
+                return False
+            if not check_celery_available():
+                return False
+            task_state = safe_check_task_state(scan.celery_task_id, current_app.celery)
+            return task_state is None or task_state in ('SUCCESS', 'FAILURE', 'REVOKED')
+        except Exception:
+            return False  # Celery check failed, rely on time-based detection
+
     def _check_stuck_scans(self):
         """Check for stuck scans and mark them as crashed"""
         try:
@@ -846,20 +868,6 @@ class MediaScheduler:
                     if start_time and start_time.tzinfo is None:
                         start_time = start_time.replace(tzinfo=timezone.utc)
 
-                    # Secondary check: if scan has a Celery task, verify task is still alive.
-                    # A lost/crashed Celery task with a stale last_update is a definitive indicator.
-                    celery_task_gone = False
-                    if scan.celery_task_id:
-                        try:
-                            from pixelprobe.utils.celery_utils import check_celery_available, safe_check_task_state
-                            from flask import current_app
-                            if check_celery_available():
-                                task_state = safe_check_task_state(scan.celery_task_id, current_app.celery)
-                                if task_state in ['SUCCESS', 'FAILURE', 'REVOKED'] or task_state is None:
-                                    celery_task_gone = True
-                        except Exception:
-                            pass  # Celery check failed, rely on time-based detection
-
                     # Check if scan has been running for more than 30 minutes without update
                     if last_update and last_update < stuck_threshold:
                         logger.warning(f"Marking stuck scan {scan.scan_id} as crashed - no update since {last_update}")
@@ -867,7 +875,8 @@ class MediaScheduler:
                         scan.phase = 'crashed'
                         scan.error_message = f"Scan appears stuck - no activity for over 30 minutes (last update: {last_update})"
                         scans_to_mark.append(scan)
-                    elif celery_task_gone and last_update and last_update < (current_time - timedelta(minutes=5)):
+                    elif (last_update and last_update < (current_time - timedelta(minutes=5))
+                          and self._celery_task_gone(scan)):
                         # Celery task is gone AND no update for 5+ minutes -- crashed
                         logger.warning(f"Marking scan {scan.scan_id} as crashed - Celery task gone and no update since {last_update}")
                         scan.is_active = False

--- a/pixelprobe/scheduler_lock.py
+++ b/pixelprobe/scheduler_lock.py
@@ -1,9 +1,13 @@
 """
 Redis-based distributed lock for scheduler coordination across containers.
 
-Uses Redis SETNX for atomic lock acquisition with a 60-second TTL for auto-recovery.
-A heartbeat thread refreshes the lock every 30 seconds to keep it alive.
-Falls back to file-based locking when Redis is unavailable.
+Exactly one process across all containers may own the scheduler. Ownership is
+claimed strictly via SET NX with a 60-second TTL; a dead holder is recovered by
+TTL expiry, which standby processes pick up in their retry loop. There is no
+force-acquire heuristic: hostname/pid are not reliable identity (containers in
+a podman pod share a hostname while pids collide across pid namespaces), so the
+lock value carries a per-process uuid and ownership checks compare the exact
+value. Falls back to file-based locking when Redis is unavailable.
 """
 
 import os
@@ -11,69 +15,78 @@ import logging
 import threading
 import time
 import socket
-from datetime import datetime, timezone
+import uuid
 
 logger = logging.getLogger(__name__)
 
 LOCK_KEY = 'pixelprobe:scheduler:lock'
-
-
-def parse_scheduler_lock(lock_value):
-    """Parse lock value into (hostname, pid, timestamp_str).
-
-    Lock formats:
-    - New: "hostname:pid:timestamp" (e.g., "pixelprobe-app:123:2026-01-01T00:00:00+00:00")
-    - Old: "pid:timestamp" (e.g., "123:2026-01-01T00:00:00+00:00")
-    """
-    parts = lock_value.split(':')
-    if len(parts) >= 3 and not parts[0].isdigit():
-        return parts[0], parts[1], ':'.join(parts[2:])
-    return None, parts[0], ':'.join(parts[1:])
-
-
-def should_force_acquire_lock(lock_hostname, lock_pid, lock_age,
-                              my_hostname, my_pid, staleness_threshold=65):
-    """Determine if we should force-acquire an existing lock.
-
-    Returns (should_acquire: bool, reason: str).
-    """
-    if lock_hostname == my_hostname and lock_pid == my_pid:
-        return True, "self-lock"
-    if lock_hostname == my_hostname:
-        if lock_age > staleness_threshold:
-            return True, "stale-sibling"
-        return False, "active-sibling"
-    if lock_age > staleness_threshold:
-        return True, "stale-remote"
-    return False, "active-remote"
-
-
+LOCK_TTL_SECS = 60
 HEARTBEAT_INTERVAL_SECS = 30
+# After a failed refresh, retry quickly: waiting a full interval would leave
+# only one attempt before the TTL lapses and a standby can take the lock.
+HEARTBEAT_FAILURE_RETRY_SECS = 5
+RETRY_INTERVAL_SECS = 30
+
+# Refresh the TTL only if this process still holds the lock.
+_REFRESH_IF_OWNER_SCRIPT = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('expire', KEYS[1], ARGV[2])
+end
+return 0
+"""
 
 
-def _start_heartbeat(lock_key, redis_client, container_hostname, scheduler_initialized):
+def scheduler_enabled():
+    """Whether this process may run the scheduler (SCHEDULER_ENABLED env var)."""
+    return os.environ.get('SCHEDULER_ENABLED', 'true').strip().lower() not in ('false', '0', 'no')
+
+
+def make_lock_value():
+    """Unique per-process lock value: hostname and pid for log readability,
+    uuid for actual identity."""
+    return f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex}"
+
+
+def _start_heartbeat(lock_key, redis_client, lock_value, scheduler_initialized):
     """Start a daemon thread that refreshes the scheduler lock periodically.
 
-    Critically, a refresh failure is RETRIED indefinitely rather than breaking
-    the loop. The previous implementation broke out on the first exception, so a
-    single transient Redis blip permanently stopped refreshing and silently
-    abandoned the lock. Now the loop keeps trying; when Redis recovers the next
-    refresh re-establishes the TTL and the lock is never abandoned.
+    The refresh is an atomic compare-and-expire: it only extends the TTL while
+    this process still holds the lock, so it can never overwrite another
+    holder. If the key vanished (a Redis outage expires it for everyone), the
+    thread reclaims it with SET NX. If another process claimed it in the
+    meantime, we log loudly but keep the scheduler running -- shutting a
+    BackgroundScheduler down is one-way (it cannot be started again), and in a
+    single-container deployment that would leave no scheduler at all. (A
+    future refinement could pause() here and resume() on reclaim.)
 
-    A full Redis outage expires the lock for everyone (no sibling can acquire it
-    either), so this process simply resumes ownership on recovery -- it does not
-    shut the scheduler down (a BackgroundScheduler cannot be restarted, and in a
-    single-container deployment there is no sibling to take over).
+    A refresh failure is RETRIED indefinitely rather than breaking the loop;
+    a single transient Redis blip must not silently abandon the lock.
     """
     def heartbeat_loop():
         consecutive_failures = 0
         while scheduler_initialized[0]:
-            time.sleep(HEARTBEAT_INTERVAL_SECS)
+            time.sleep(HEARTBEAT_FAILURE_RETRY_SECS if consecutive_failures
+                       else HEARTBEAT_INTERVAL_SECS)
             if not scheduler_initialized[0]:
                 break
             try:
-                refresh_value = f"{container_hostname}:{os.getpid()}:{datetime.now(timezone.utc).isoformat()}"
-                redis_client.set(lock_key, refresh_value, ex=60)
+                refreshed = redis_client.eval(
+                    _REFRESH_IF_OWNER_SCRIPT, 1, lock_key, lock_value, LOCK_TTL_SECS
+                )
+                if not refreshed:
+                    reclaimed = redis_client.set(lock_key, lock_value, nx=True, ex=LOCK_TTL_SECS)
+                    if reclaimed:
+                        logger.info(
+                            f"Scheduler lock had expired; reclaimed in process {os.getpid()}"
+                        )
+                    else:
+                        holder = redis_client.get(lock_key)
+                        holder = holder.decode('utf-8') if isinstance(holder, bytes) else holder
+                        logger.warning(
+                            f"Scheduler lock now held by {holder} but process "
+                            f"{os.getpid()} is still running a scheduler -- "
+                            f"duplicate scheduled runs are possible until one restarts"
+                        )
                 if consecutive_failures:
                     logger.info(
                         f"Scheduler lock refresh recovered after "
@@ -94,67 +107,49 @@ def _start_heartbeat(lock_key, redis_client, container_hostname, scheduler_initi
     return heartbeat_thread
 
 
-def _try_acquire_and_init(redis_client, lock_key, lock_value, container_hostname,
-                          scheduler, app, scheduler_initialized):
-    """Acquire the lock, initialize the scheduler, and start heartbeat."""
+def _init_scheduler_and_heartbeat(redis_client, lock_key, lock_value,
+                                  scheduler, app, scheduler_initialized):
+    """Initialize the scheduler and start the lock heartbeat."""
     scheduler.init_app(app)
     scheduler_initialized[0] = True
     app.scheduler_redis_lock_key = lock_key
-    _start_heartbeat(lock_key, redis_client, container_hostname, scheduler_initialized)
+    _start_heartbeat(lock_key, redis_client, lock_value, scheduler_initialized)
 
 
-def _start_retry_thread(redis_client, lock_key, container_hostname,
+def _start_retry_thread(redis_client, lock_key, lock_value,
                         scheduler, app, scheduler_initialized):
-    """Start background retry thread for stale lock recovery."""
+    """Start a standby thread that takes over when the holder's lock expires.
+
+    Retries indefinitely: failover must work whenever the holder dies, not just
+    during the first few minutes after boot. Acquisition is SET NX only -- a
+    live lock is never stolen.
+    """
     def retry_scheduler_lock():
         retry_count = 0
-        max_retries = 10
-
-        while not scheduler_initialized[0] and retry_count < max_retries:
-            time.sleep(30)
+        while not scheduler_initialized[0]:
+            time.sleep(RETRY_INTERVAL_SECS)
             retry_count += 1
-
             try:
-                current_lock = redis_client.get(lock_key)
-                new_value = f"{container_hostname}:{os.getpid()}:{datetime.now(timezone.utc).isoformat()}"
+                # Our own writes always carry a TTL; a persistent key (manual
+                # redis-cli SET, foreign writer) would otherwise deadlock every
+                # standby forever. Give it a TTL so normal expiry recovery applies.
+                if redis_client.ttl(lock_key) == -1:
+                    logger.warning(f"Scheduler lock key has no TTL, applying {LOCK_TTL_SECS}s expiry")
+                    redis_client.expire(lock_key, LOCK_TTL_SECS)
 
-                if not current_lock:
-                    retry_acquired = redis_client.set(lock_key, new_value, nx=True, ex=60)
-                    if retry_acquired:
-                        logger.info(f"Retry #{retry_count}: Acquired scheduler lock, initializing scheduler")
-                        with app.app_context():
-                            _try_acquire_and_init(
-                                redis_client, lock_key, new_value, container_hostname,
-                                scheduler, app, scheduler_initialized
-                            )
-                        break
-                else:
-                    lock_str = current_lock.decode('utf-8') if isinstance(current_lock, bytes) else current_lock
-                    retry_hostname, retry_pid, retry_ts_str = parse_scheduler_lock(lock_str)
-                    lock_ts = datetime.fromisoformat(retry_ts_str)
-                    current_age = (datetime.now(timezone.utc) - lock_ts).total_seconds()
-
-                    retry_should_acquire, retry_reason = should_force_acquire_lock(
-                        retry_hostname, retry_pid, current_age,
-                        container_hostname, str(os.getpid())
+                acquired = redis_client.set(lock_key, lock_value, nx=True, ex=LOCK_TTL_SECS)
+                if acquired:
+                    logger.info(
+                        f"Retry #{retry_count}: Acquired scheduler lock, initializing scheduler"
                     )
-
-                    if retry_should_acquire:
-                        redis_client.set(lock_key, new_value, ex=60)
-                        logger.info(f"Retry #{retry_count}: Acquired lock (reason={retry_reason}, age={current_age:.0f}s), initializing scheduler")
-                        with app.app_context():
-                            _try_acquire_and_init(
-                                redis_client, lock_key, new_value, container_hostname,
-                                scheduler, app, scheduler_initialized
-                            )
-                        break
-                    else:
-                        logger.debug(f"Retry #{retry_count}: Lock still held (reason={retry_reason}, age={current_age:.0f}s)")
+                    with app.app_context():
+                        _init_scheduler_and_heartbeat(
+                            redis_client, lock_key, lock_value,
+                            scheduler, app, scheduler_initialized
+                        )
+                    break
             except Exception as retry_err:
-                logger.warning(f"Retry #{retry_count} failed: {retry_err}")
-
-        if not scheduler_initialized[0]:
-            logger.warning("Scheduler lock retry exhausted - another process must have it")
+                logger.warning(f"Scheduler lock retry #{retry_count} failed: {retry_err}")
 
     retry_thread = threading.Thread(target=retry_scheduler_lock, daemon=True)
     retry_thread.start()
@@ -168,51 +163,37 @@ def initialize_scheduler_with_lock(app, scheduler):
     """
     from pixelprobe.progress_utils import get_redis_client
 
+    if not scheduler_enabled():
+        # Lets a deployment pin the scheduler to one container (e.g. false on
+        # web, default true on the celery worker) instead of having every
+        # process race for the distributed lock.
+        logger.info(f"SCHEDULER_ENABLED is false, skipping scheduler initialization in process {os.getpid()}")
+        return False
+
     redis_client = get_redis_client()
     scheduler_initialized = [False]
-    container_hostname = socket.gethostname()
+    lock_value = make_lock_value()
 
     if redis_client:
         try:
-            lock_value = f"{container_hostname}:{os.getpid()}:{datetime.now(timezone.utc).isoformat()}"
-            acquired = redis_client.set(LOCK_KEY, lock_value, nx=True, ex=60)
+            acquired = redis_client.set(LOCK_KEY, lock_value, nx=True, ex=LOCK_TTL_SECS)
 
             if acquired:
                 logger.info(f"Acquired Redis scheduler lock in process {os.getpid()}, initializing scheduler")
-                _try_acquire_and_init(
-                    redis_client, LOCK_KEY, lock_value, container_hostname,
+                _init_scheduler_and_heartbeat(
+                    redis_client, LOCK_KEY, lock_value,
                     scheduler, app, scheduler_initialized
                 )
             else:
-                existing = redis_client.get(LOCK_KEY)
-                if existing:
-                    existing = existing.decode('utf-8') if isinstance(existing, bytes) else existing
-                    try:
-                        lock_hostname, lock_pid, lock_timestamp_str = parse_scheduler_lock(existing)
-                        lock_timestamp = datetime.fromisoformat(lock_timestamp_str)
-                        lock_age = (datetime.now(timezone.utc) - lock_timestamp).total_seconds()
-
-                        should_acquire, reason = should_force_acquire_lock(
-                            lock_hostname, lock_pid, lock_age,
-                            container_hostname, str(os.getpid())
-                        )
-
-                        if should_acquire:
-                            logger.warning(f"Acquiring scheduler lock (reason={reason}, age={lock_age:.0f}s, holder={existing})")
-                            redis_client.set(LOCK_KEY, lock_value, ex=60)
-                            logger.info(f"Acquired scheduler lock in process {os.getpid()}, initializing scheduler")
-                            _try_acquire_and_init(
-                                redis_client, LOCK_KEY, lock_value, container_hostname,
-                                scheduler, app, scheduler_initialized
-                            )
-                        else:
-                            logger.info(f"Scheduler lock held by sibling/remote (reason={reason}, holder={existing}, age={lock_age:.0f}s), skipping in process {os.getpid()}")
-                            _start_retry_thread(
-                                redis_client, LOCK_KEY, container_hostname,
-                                scheduler, app, scheduler_initialized
-                            )
-                    except Exception as parse_err:
-                        logger.info(f"Scheduler already running (lock held by: {existing}), skipping in process {os.getpid()}")
+                holder = redis_client.get(LOCK_KEY)
+                holder = holder.decode('utf-8') if isinstance(holder, bytes) else holder
+                logger.info(
+                    f"Scheduler lock held by {holder}, standing by in process {os.getpid()}"
+                )
+                _start_retry_thread(
+                    redis_client, LOCK_KEY, lock_value,
+                    scheduler, app, scheduler_initialized
+                )
 
         except Exception as e:
             logger.warning(f"Redis lock failed ({e}), falling back to file lock")

--- a/pixelprobe/utils/celery_utils.py
+++ b/pixelprobe/utils/celery_utils.py
@@ -1,6 +1,10 @@
 """Celery utility functions for PixelProbe"""
 
 import logging
+import time
+
+import redis
+from celery.result import AsyncResult
 from flask import current_app
 
 logger = logging.getLogger(__name__)
@@ -23,6 +27,48 @@ def check_celery_available():
             celery_enabled = False
 
     return celery_enabled
+
+
+def safe_check_task_state(celery_task_id, app, max_retries=3, base_delay=0.5):
+    """
+    Safely check Celery task state with retry logic for Redis connection errors.
+
+    v2.5.54: Added to protect AsyncResult.state access from Redis connection crashes.
+    v2.6.65: Moved here from scan_routes so the scheduler can import it -- its
+    previous import from this module raised ImportError, which was silently
+    swallowed and left the stuck-scan sweep's task check permanently disabled.
+
+    Args:
+        celery_task_id: Celery task ID
+        app: Celery application instance
+        max_retries: Number of retry attempts
+        base_delay: Base delay between retries in seconds
+
+    Returns:
+        Task state string or None if unable to determine state
+    """
+    from pixelprobe.progress_utils import reset_redis_pool
+
+    for attempt in range(max_retries):
+        try:
+            result = AsyncResult(celery_task_id, app=app)
+            return result.state
+        except (redis.ConnectionError, redis.TimeoutError, ConnectionResetError, AttributeError) as e:
+            # Reset connection pool on first failure
+            if attempt == 0:
+                reset_redis_pool()
+
+            if attempt < max_retries - 1:
+                delay = base_delay * (attempt + 1)
+                logger.warning(f"Redis error checking task state (attempt {attempt + 1}/{max_retries}), retrying in {delay}s: {type(e).__name__}: {e}")
+                time.sleep(delay)
+            else:
+                logger.error(f"Failed to check task state after {max_retries} attempts: {type(e).__name__}: {e}")
+                return None
+        except Exception as e:
+            logger.error(f"Unexpected error checking task state: {type(e).__name__}: {e}")
+            return None
+    return None
 
 
 def _noop_on_task_call(producer, task_id):

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.64'
+_DEFAULT_VERSION = '2.6.65'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ import tempfile
 import os
 import shutil
 from pathlib import Path
+
+# Required before any pixelprobe.config import; set here (not only inside the
+# app fixture) so tests that import config directly also work in isolation
+os.environ.setdefault('SECRET_KEY', 'test-secret-key')
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 

--- a/tests/test_gunicorn_conf.py
+++ b/tests/test_gunicorn_conf.py
@@ -1,0 +1,40 @@
+import importlib.util
+import os
+
+CONF_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'gunicorn.conf.py'
+)
+
+
+def load_conf():
+    spec = importlib.util.spec_from_file_location('gunicorn_conf', CONF_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestGunicornConf:
+    """GUNICORN_BIND must default to the historical IPv4 bind and accept a
+    comma-separated list for dual-stack setups (issue 63)."""
+
+    def test_defaults_match_previous_dockerfile_cmd(self, monkeypatch):
+        for var in ('GUNICORN_BIND', 'GUNICORN_WORKERS', 'GUNICORN_TIMEOUT'):
+            monkeypatch.delenv(var, raising=False)
+        conf = load_conf()
+        assert conf.bind == ['0.0.0.0:5000']
+        assert conf.workers == 4
+        assert conf.timeout == 300
+        assert conf.accesslog == '-'
+        assert conf.errorlog == '-'
+
+    def test_single_ipv6_bind(self, monkeypatch):
+        monkeypatch.setenv('GUNICORN_BIND', '[::]:5000')
+        assert load_conf().bind == ['[::]:5000']
+
+    def test_bind_list_strips_and_drops_blanks(self, monkeypatch):
+        monkeypatch.setenv('GUNICORN_BIND', '0.0.0.0:5000, [::]:5000,,')
+        assert load_conf().bind == ['0.0.0.0:5000', '[::]:5000']
+
+    def test_blank_bind_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv('GUNICORN_BIND', '  ,')
+        assert load_conf().bind == ['0.0.0.0:5000']

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,182 +1,117 @@
+import time
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+import pixelprobe.progress_utils as pu
+import pixelprobe.scheduler_lock as sl
 from pixelprobe.scheduler import MediaScheduler
 from pixelprobe.models import db, ScanSchedule
 
 
-class TestSchedulerLockHelpers:
-    """Test scheduler lock helper functions for multi-worker coordination."""
+class TestSchedulerLock:
+    """A live scheduler lock must never be stolen. hostname:pid is not a safe
+    identity (podman pod containers share a hostname while pids collide across
+    pid namespaces), so ownership is a unique per-process value and acquisition
+    is strictly SET NX."""
 
-    def test_parse_scheduler_lock_new_format(self):
-        """Test parsing new lock format: hostname:pid:timestamp"""
-        # Import the functions from app module
-        import sys
+    def test_lock_value_unique_for_same_hostname_and_pid(self):
+
+        # Same process, same hostname, same pid -- values still differ.
+        assert sl.make_lock_value() != sl.make_lock_value()
+
+    def test_does_not_steal_live_lock_even_with_colliding_identity(self, monkeypatch):
+        """The podman-pod scenario: holder has our hostname AND our pid."""
         import os
-        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        import socket
 
-        # Test parsing logic directly (mirrors app.py implementation)
-        lock_value = "pixelprobe-app:12345:2026-01-01T00:00:00+00:00"
-        parts = lock_value.split(':')
-        if len(parts) >= 3 and not parts[0].isdigit():
-            hostname = parts[0]
-            pid = parts[1]
-            timestamp_str = ':'.join(parts[2:])
-        else:
-            hostname = None
-            pid = parts[0]
-            timestamp_str = ':'.join(parts[1:])
+        redis_client = MagicMock()
+        redis_client.set.return_value = None  # SET NX failed: lock is held
+        redis_client.get.return_value = f"{socket.gethostname()}:{os.getpid()}:deadbeef".encode()
+        monkeypatch.setattr(pu, 'get_redis_client', lambda: redis_client)
+        retry_spy = MagicMock()
+        monkeypatch.setattr(sl, '_start_retry_thread', retry_spy)
 
-        assert hostname == "pixelprobe-app"
-        assert pid == "12345"
-        assert timestamp_str == "2026-01-01T00:00:00+00:00"
+        scheduler = MagicMock()
+        result = sl.initialize_scheduler_with_lock(MagicMock(), scheduler)
 
-    def test_parse_scheduler_lock_old_format(self):
-        """Test parsing old lock format: pid:timestamp (no hostname)"""
-        lock_value = "12345:2026-01-01T00:00:00+00:00"
-        parts = lock_value.split(':')
-        if len(parts) >= 3 and not parts[0].isdigit():
-            hostname = parts[0]
-            pid = parts[1]
-            timestamp_str = ':'.join(parts[2:])
-        else:
-            hostname = None
-            pid = parts[0]
-            timestamp_str = ':'.join(parts[1:])
+        assert result is False
+        scheduler.init_app.assert_not_called()
+        retry_spy.assert_called_once()
+        # Every acquisition attempt was SET NX -- no unconditional overwrite.
+        for call in redis_client.set.call_args_list:
+            assert call.kwargs.get('nx') is True
 
-        assert hostname is None
-        assert pid == "12345"
-        assert timestamp_str == "2026-01-01T00:00:00+00:00"
+    def test_acquires_free_lock_and_starts_heartbeat(self, monkeypatch):
 
-    def test_should_acquire_self_lock(self):
-        """Test that same hostname AND same PID allows acquisition (self-lock refresh)."""
-        lock_hostname = "pixelprobe-app"
-        lock_pid = "12345"
-        lock_age = 10  # Recent lock
-        my_hostname = "pixelprobe-app"
-        my_pid = "12345"
+        redis_client = MagicMock()
+        redis_client.set.return_value = True
+        monkeypatch.setattr(pu, 'get_redis_client', lambda: redis_client)
+        heartbeat_spy = MagicMock()
+        monkeypatch.setattr(sl, '_start_heartbeat', heartbeat_spy)
 
-        # Same hostname AND same PID = self-lock, always acquire
-        if lock_hostname == my_hostname and lock_pid == my_pid:
-            should_acquire = True
-            reason = "self-lock"
-        elif lock_hostname == my_hostname:
-            should_acquire = lock_age > 65
-            reason = "stale-sibling" if should_acquire else "active-sibling"
-        else:
-            should_acquire = lock_age > 65
-            reason = "stale-remote" if should_acquire else "active-remote"
+        scheduler = MagicMock()
+        app = MagicMock()
+        result = sl.initialize_scheduler_with_lock(app, scheduler)
 
-        assert should_acquire is True
-        assert reason == "self-lock"
+        assert result is True
+        scheduler.init_app.assert_called_once_with(app)
+        heartbeat_spy.assert_called_once()
+        assert redis_client.set.call_args.kwargs.get('nx') is True
 
-    def test_should_not_acquire_active_sibling(self):
-        """Test that same hostname but different PID with fresh lock is NOT acquired."""
-        lock_hostname = "pixelprobe-app"
-        lock_pid = "12345"
-        lock_age = 10  # Recent lock (within 65s threshold)
-        my_hostname = "pixelprobe-app"
-        my_pid = "67890"  # Different PID - sibling worker
+    def test_retry_thread_acquires_after_lock_expiry(self, monkeypatch):
 
-        if lock_hostname == my_hostname and lock_pid == my_pid:
-            should_acquire = True
-            reason = "self-lock"
-        elif lock_hostname == my_hostname:
-            should_acquire = lock_age > 65
-            reason = "stale-sibling" if should_acquire else "active-sibling"
-        else:
-            should_acquire = lock_age > 65
-            reason = "stale-remote" if should_acquire else "active-remote"
+        monkeypatch.setattr(sl.time, 'sleep', lambda _s: None)
+        monkeypatch.setattr(sl, '_start_heartbeat', MagicMock())
 
-        assert should_acquire is False
-        assert reason == "active-sibling"
+        # Lock held for 14 rounds (past the old max_retries=10), then expires.
+        # Proves the standby retries indefinitely and only wins via SET NX.
+        results = [None] * 14 + [True]
+        redis_client = MagicMock()
+        redis_client.set.side_effect = results
 
-    def test_should_acquire_stale_sibling(self):
-        """Test that same hostname but different PID with stale lock IS acquired."""
-        lock_hostname = "pixelprobe-app"
-        lock_pid = "12345"
-        lock_age = 70  # Stale lock (>65s threshold)
-        my_hostname = "pixelprobe-app"
-        my_pid = "67890"  # Different PID - sibling worker
+        scheduler = MagicMock()
+        initialized = [False]
+        sl._start_retry_thread(redis_client, 'k', 'me', scheduler, MagicMock(), initialized)
 
-        if lock_hostname == my_hostname and lock_pid == my_pid:
-            should_acquire = True
-            reason = "self-lock"
-        elif lock_hostname == my_hostname:
-            should_acquire = lock_age > 65
-            reason = "stale-sibling" if should_acquire else "active-sibling"
-        else:
-            should_acquire = lock_age > 65
-            reason = "stale-remote" if should_acquire else "active-remote"
+        deadline = time.time() + 5
+        while not initialized[0] and time.time() < deadline:
+            time.sleep(0.01)
 
-        assert should_acquire is True
-        assert reason == "stale-sibling"
+        assert initialized[0] is True
+        scheduler.init_app.assert_called_once()
+        assert redis_client.set.call_count == len(results)
+        for call in redis_client.set.call_args_list:
+            assert call.kwargs.get('nx') is True
 
-    def test_should_not_acquire_active_remote(self):
-        """Test that different hostname with fresh lock is NOT acquired."""
-        lock_hostname = "other-container"
-        lock_pid = "12345"
-        lock_age = 10  # Recent lock
-        my_hostname = "pixelprobe-app"
-        my_pid = "67890"
 
-        if lock_hostname == my_hostname and lock_pid == my_pid:
-            should_acquire = True
-            reason = "self-lock"
-        elif lock_hostname == my_hostname:
-            should_acquire = lock_age > 65
-            reason = "stale-sibling" if should_acquire else "active-sibling"
-        else:
-            should_acquire = lock_age > 65
-            reason = "stale-remote" if should_acquire else "active-remote"
+class TestSchedulerEnabled:
+    """SCHEDULER_ENABLED gates whether a process competes for the lock at all."""
 
-        assert should_acquire is False
-        assert reason == "active-remote"
+    def test_default_is_enabled(self, monkeypatch):
+        monkeypatch.delenv('SCHEDULER_ENABLED', raising=False)
+        assert sl.scheduler_enabled() is True
 
-    def test_should_acquire_stale_remote(self):
-        """Test that different hostname with stale lock IS acquired."""
-        lock_hostname = "other-container"
-        lock_pid = "12345"
-        lock_age = 70  # Stale lock (>65s threshold)
-        my_hostname = "pixelprobe-app"
-        my_pid = "67890"
+    @pytest.mark.parametrize('value', ['false', 'FALSE', ' False ', '0', 'no'])
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv('SCHEDULER_ENABLED', value)
+        assert sl.scheduler_enabled() is False
 
-        if lock_hostname == my_hostname and lock_pid == my_pid:
-            should_acquire = True
-            reason = "self-lock"
-        elif lock_hostname == my_hostname:
-            should_acquire = lock_age > 65
-            reason = "stale-sibling" if should_acquire else "active-sibling"
-        else:
-            should_acquire = lock_age > 65
-            reason = "stale-remote" if should_acquire else "active-remote"
+    @pytest.mark.parametrize('value', ['true', '1', 'yes', 'anything'])
+    def test_enabled_values(self, monkeypatch, value):
+        monkeypatch.setenv('SCHEDULER_ENABLED', value)
+        assert sl.scheduler_enabled() is True
 
-        assert should_acquire is True
-        assert reason == "stale-remote"
+    def test_disabled_skips_lock_arbitration(self, monkeypatch):
+        monkeypatch.setenv('SCHEDULER_ENABLED', 'false')
+        redis_client = MagicMock()
+        monkeypatch.setattr(pu, 'get_redis_client', lambda: redis_client)
 
-    def test_old_format_lock_treated_as_remote(self):
-        """Test that old format locks (no hostname) are treated as remote."""
-        lock_hostname = None  # Old format has no hostname
-        lock_pid = "12345"
-        lock_age = 10  # Recent lock
-        my_hostname = "pixelprobe-app"
-        my_pid = "67890"
-
-        # When hostname is None, it can't match my_hostname, so it's treated as remote
-        if lock_hostname == my_hostname and lock_pid == my_pid:
-            should_acquire = True
-            reason = "self-lock"
-        elif lock_hostname == my_hostname:
-            should_acquire = lock_age > 65
-            reason = "stale-sibling" if should_acquire else "active-sibling"
-        else:
-            should_acquire = lock_age > 65
-            reason = "stale-remote" if should_acquire else "active-remote"
-
-        assert should_acquire is False
-        assert reason == "active-remote"
+        scheduler = MagicMock()
+        assert sl.initialize_scheduler_with_lock(MagicMock(), scheduler) is False
+        scheduler.init_app.assert_not_called()
+        redis_client.set.assert_not_called()
 
 
 class TestMediaScheduler:
@@ -356,30 +291,28 @@ class TestQueueConflictRetry:
 
 class TestHeartbeatRecovery:
     """The lock heartbeat must keep retrying through Redis failures rather than
-    breaking out forever (which silently abandoned the lock). It must never
-    relinquish the lock on a transient error, and it stops only when the loop's
-    initialized flag is cleared (process teardown)."""
+    breaking out forever (which silently abandoned the lock). It refreshes the
+    TTL only while it still owns the lock (atomic compare-and-expire) and never
+    overwrites another holder."""
 
     def test_keeps_retrying_through_failures_and_recovers(self, monkeypatch):
-        from unittest.mock import MagicMock
-        import pixelprobe.scheduler_lock as sl
 
         monkeypatch.setattr(sl.time, 'sleep', lambda _s: None)
         initialized = [True]
         calls = {'n': 0}
 
-        def set_side_effect(*_a, **_k):
+        def eval_side_effect(*_a, **_k):
             calls['n'] += 1
             if calls['n'] <= 2:
                 raise Exception('transient blip')
             # Recovered after 2 failures: stop the loop deterministically.
             initialized[0] = False
-            return True
+            return 1
 
         redis_client = MagicMock()
-        redis_client.set.side_effect = set_side_effect
+        redis_client.eval.side_effect = eval_side_effect
 
-        t = sl._start_heartbeat('k', redis_client, 'host', initialized)
+        t = sl._start_heartbeat('k', redis_client, 'me', initialized)
         t.join(timeout=5)
 
         assert not t.is_alive()
@@ -387,14 +320,12 @@ class TestHeartbeatRecovery:
         assert calls['n'] >= 3
 
     def test_sustained_failure_does_not_abandon_loop(self, monkeypatch):
-        from unittest.mock import MagicMock
-        import pixelprobe.scheduler_lock as sl
 
         monkeypatch.setattr(sl.time, 'sleep', lambda _s: None)
         initialized = [True]
         calls = {'n': 0}
 
-        def set_side_effect(*_a, **_k):
+        def eval_side_effect(*_a, **_k):
             calls['n'] += 1
             if calls['n'] >= 5:
                 # Stop the test loop; in production it would keep retrying.
@@ -402,14 +333,84 @@ class TestHeartbeatRecovery:
             raise Exception('redis down')
 
         redis_client = MagicMock()
-        redis_client.set.side_effect = set_side_effect
+        redis_client.eval.side_effect = eval_side_effect
 
-        t = sl._start_heartbeat('k', redis_client, 'host', initialized)
+        t = sl._start_heartbeat('k', redis_client, 'me', initialized)
         t.join(timeout=5)
 
         assert not t.is_alive()
         # The loop retried every interval instead of bailing on the first error.
         assert calls['n'] >= 5
+
+    def test_refresh_while_owner_never_writes(self, monkeypatch):
+        """While we still hold the lock, the heartbeat only extends the TTL."""
+
+        monkeypatch.setattr(sl.time, 'sleep', lambda _s: None)
+        initialized = [True]
+        calls = {'n': 0}
+
+        def eval_side_effect(*args, **_k):
+            calls['n'] += 1
+            assert args[3] == 'me'  # compare-and-expire against OUR value
+            if calls['n'] >= 3:
+                initialized[0] = False
+            return 1
+
+        redis_client = MagicMock()
+        redis_client.eval.side_effect = eval_side_effect
+
+        t = sl._start_heartbeat('k', redis_client, 'me', initialized)
+        t.join(timeout=5)
+
+        assert not t.is_alive()
+        redis_client.set.assert_not_called()
+
+    def test_reclaims_expired_key_with_set_nx(self, monkeypatch):
+        """Redis outage expired the key: heartbeat reclaims it, but only NX."""
+
+        monkeypatch.setattr(sl.time, 'sleep', lambda _s: None)
+        initialized = [True]
+
+        def eval_side_effect(*_a, **_k):
+            return 0  # no longer owner (key gone)
+
+        def set_side_effect(*_a, **kwargs):
+            initialized[0] = False
+            assert kwargs.get('nx') is True
+            return True
+
+        redis_client = MagicMock()
+        redis_client.eval.side_effect = eval_side_effect
+        redis_client.set.side_effect = set_side_effect
+
+        t = sl._start_heartbeat('k', redis_client, 'me', initialized)
+        t.join(timeout=5)
+
+        assert not t.is_alive()
+        redis_client.set.assert_called_once()
+
+    def test_never_overwrites_another_holder(self, monkeypatch):
+        """Another process holds the lock now: warn, do not clobber it."""
+
+        monkeypatch.setattr(sl.time, 'sleep', lambda _s: None)
+        initialized = [True]
+
+        def set_side_effect(*_a, **kwargs):
+            initialized[0] = False
+            assert kwargs.get('nx') is True
+            return None  # someone else got there first
+
+        redis_client = MagicMock()
+        redis_client.eval.return_value = 0
+        redis_client.set.side_effect = set_side_effect
+        redis_client.get.return_value = b'other-host:1:cafef00d'
+
+        t = sl._start_heartbeat('k', redis_client, 'me', initialized)
+        t.join(timeout=5)
+
+        assert not t.is_alive()
+        # The only write attempted was the NX reclaim, which lost cleanly.
+        redis_client.set.assert_called_once()
 
 
 class TestScanningReclaim:
@@ -453,6 +454,103 @@ class TestScanningReclaim:
             assert r.scan_status == 'scanning'
 
 
+class TestStuckScanChunkAwareness:
+    """A finished orchestrator task must not get a scan marked crashed while
+    chunk tasks are still active (issue #65): the orchestrator returns as soon
+    as chunks are queued, so its SUCCESS state says nothing about the scan."""
+
+    @pytest.fixture
+    def scheduler(self, app):
+        scheduler = MediaScheduler()
+        scheduler.init_app(app)
+        yield scheduler
+        scheduler.shutdown()
+
+    def _make_stale_scan(self, db, scan_id, with_active_chunk):
+        from pixelprobe.models import ScanState, ScanChunk
+        # 10 min stale: past the 5-min task-gone threshold, under the 30-min
+        # hard threshold, so only the task-gone branch is in play.
+        scan = ScanState(
+            scan_id=scan_id, is_active=True, phase='scanning',
+            celery_task_id='orchestrator-task',
+            last_update=datetime.now(timezone.utc) - timedelta(minutes=10),
+        )
+        db.session.add(scan)
+        if with_active_chunk:
+            db.session.add(ScanChunk(
+                scan_id=scan_id, chunk_id='chunk-1',
+                directory_path='/media', status='processing',
+            ))
+        db.session.commit()
+        return scan
+
+    def _run_check(self, scheduler, app, monkeypatch):
+        import pixelprobe.utils.celery_utils as cu
+        monkeypatch.setattr(cu, 'check_celery_available', lambda: True)
+        monkeypatch.setattr(cu, 'safe_check_task_state', lambda *_a, **_k: 'SUCCESS')
+        app.celery = MagicMock()
+        scheduler._check_stuck_scans()
+
+    def test_active_chunks_prevent_false_crash(self, scheduler, app, db, monkeypatch):
+        from pixelprobe.models import ScanState
+        self._make_stale_scan(db, 'chunked-live', with_active_chunk=True)
+        self._run_check(scheduler, app, monkeypatch)
+
+        db.session.expire_all()
+        scan = ScanState.query.filter_by(scan_id='chunked-live').first()
+        assert scan.phase == 'scanning'
+        assert scan.is_active is True
+
+    def test_scan_without_chunks_is_marked_crashed(self, scheduler, app, db, monkeypatch):
+        """Positive control: with no live chunks the task-gone branch still
+        fires, proving the previous test is not passing vacuously."""
+        from pixelprobe.models import ScanState
+        self._make_stale_scan(db, 'chunked-dead', with_active_chunk=False)
+        self._run_check(scheduler, app, monkeypatch)
+
+        db.session.expire_all()
+        scan = ScanState.query.filter_by(scan_id='chunked-dead').first()
+        assert scan.phase == 'crashed'
+        assert scan.is_active is False
+
+    def test_has_active_chunks_helper(self, app, db):
+        from pixelprobe.models import ScanChunk
+        db.session.add(ScanChunk(scan_id='s-live', chunk_id='c1',
+                                 directory_path='/media', status='processing'))
+        db.session.add(ScanChunk(scan_id='s-done', chunk_id='c1',
+                                 directory_path='/media', status='completed'))
+        db.session.commit()
+
+        assert ScanChunk.has_active('s-live')
+        assert not ScanChunk.has_active('s-done')
+        assert not ScanChunk.has_active('s-none')
+
+
+class TestUTCSessionTimezone:
+    """The DB session timezone must be pinned to UTC: the app stores aware-UTC
+    datetimes in naive TIMESTAMP columns and reads them back assuming UTC, so
+    a non-UTC PostgreSQL session timezone stores local wall time and makes
+    every scan look hours stale to the stuck-scan checks (issue #65)."""
+
+    def test_all_configs_pin_session_timezone_to_utc(self):
+        from pixelprobe.config import Config, TestingConfig
+        for cfg in (Config, TestingConfig):
+            assert cfg.SQLALCHEMY_ENGINE_OPTIONS['connect_args']['options'] == '-c timezone=UTC'
+
+    @pytest.mark.parametrize('config_name', ['Config', 'TestingConfig'])
+    def test_init_app_keeps_timezone_option(self, monkeypatch, config_name):
+        """Both init_app overrides rebuild connect_args from scratch -- each
+        must re-include the timezone pin."""
+        from flask import Flask
+        import pixelprobe.config as config_module
+        cfg = getattr(config_module, config_name)
+        monkeypatch.setattr(cfg, 'POSTGRES_PASSWORD', 'pw')
+        flask_app = Flask(__name__)
+        cfg.init_app(flask_app)
+        connect_args = flask_app.config['SQLALCHEMY_ENGINE_OPTIONS']['connect_args']
+        assert connect_args['options'] == '-c timezone=UTC'
+
+
 class TestSchedulerRetryGaps:
     """Phase 2: a scheduled fire must never be silently dropped on lock
     contention or an API 409, and last_run advances only on a confirmed start."""
@@ -482,14 +580,12 @@ class TestSchedulerRetryGaps:
         assert scheduler.pending_retries.get('periodic') == 1
 
     def test_handle_response_200_clears_and_returns_true(self, scheduler):
-        from unittest.mock import MagicMock
         scheduler.pending_retries['schedule_5'] = 2
         resp = MagicMock(status_code=200)
         assert scheduler._handle_scan_response('schedule_5', lambda _i: None, (5,), resp) is True
         assert 'schedule_5' not in scheduler.pending_retries
 
     def test_handle_response_409_queues_retry(self, scheduler):
-        from unittest.mock import MagicMock
         resp = MagicMock(status_code=409)
         assert scheduler._handle_scan_response('schedule_6', lambda _i: None, (6,), resp) is False
         assert scheduler.pending_retries.get('schedule_6') == 1


### PR DESCRIPTION
Fixes #64, fixes #65, fixes #63.

## Scheduler lock contention between web and Celery containers (#64)

Root cause: every process importing the app raced for the Redis scheduler lock, and lock identity was `hostname:pid`. In podman pods, containers share a hostname (UTS namespace) while pids collide across pid namespaces, so:

- a hostname+pid collision triggered the "self-lock" force-acquire and let one container steal a live lock
- cross-container processes classified as "sibling", producing the `reason=active-sibling` retry noise from the issue
- after a steal, the heartbeat overwrote the lock key unconditionally, so two schedulers ran at once (duplicate scheduled scans)

Fix: lock values now carry a per-process uuid, acquisition is strictly `SET NX` with a 60s TTL (dead holders recover via expiry, never force-steal), the heartbeat refreshes the TTL with an atomic compare-and-expire Lua script that cannot clobber another holder, and the standby retry loop runs indefinitely instead of giving up 5 minutes after boot.

New `SCHEDULER_ENABLED` env var (default `true`) keeps a container out of lock arbitration entirely. docker-compose.yml now sets it to `false` on the web service so only the Celery worker runs the scheduler, matching the documented intent. Note: this flag did not exist before this PR, so setting it previously had no effect.

## Active scans falsely marked crashed (#65)

Two compounding defects:

1. The app writes timezone-aware UTC datetimes into naive `TIMESTAMP` columns and reads them back assuming UTC. PostgreSQL converts aware values to the *session* timezone before dropping the offset, so on a server with a non-UTC default timezone (e.g. `TZ` set on the postgres container) every scan timestamp was stored as local wall time. A running scan looked hours stale and the stuck-scan checks marked it crashed seconds after start - exactly the `phase=crashed` / `is_active=False` flip in the issue logs while `files_processed` kept climbing. The session timezone is now pinned to UTC on every engine (Flask engine via config.py, worker engine in media_checker.py).
2. The stuck-scan checks treated the orchestrator task's SUCCESS state as "task lost" - but the orchestrator finishes as soon as chunk tasks are queued. A scan now counts as alive while any of its chunks are pending/processing and it has updated within the last 30 minutes; the 30-minute no-progress hard timeout remains as the backstop so a dead worker cannot block scan launches forever.

Also fixed: the scheduler sweep's Celery task check had been silently disabled since it was added - it imported `safe_check_task_state` from a module that never contained it and swallowed the ImportError. The function now lives in `pixelprobe/utils/celery_utils.py` where both callers import it.

The log-handler transaction poisoning mentioned in the issue already self-heals via the session recovery shipped in v2.6.39 (rollback + session.remove on flush failure); the bursts in the logs line up with the reporter's Postgres restart.

## Configurable gunicorn bind for IPv6 / rootless podman (#63)

Gunicorn settings moved from the hardcoded Dockerfile CMD into `gunicorn.conf.py`. `GUNICORN_BIND` accepts a comma-separated list of listen addresses; the default is unchanged (`0.0.0.0:5000`), so existing deployments behave as before. For dual-stack, set `GUNICORN_BIND=[::]:5000` - on kernels with `net.ipv6.bindv6only=0` (the Linux default) the IPv6 wildcard also accepts IPv4. Do not list both wildcards on such kernels (the second bind fails with `EADDRINUSE`). `GUNICORN_WORKERS`, `GUNICORN_TIMEOUT`, and `GUNICORN_LOG_LEVEL` are also overridable, with blank/garbage values falling back to defaults instead of crash-looping the container.

The ffmpeg 8 / ImageMagick 7 / Valkey / Postgres 18 suggestions from #63 are out of scope here and worth tracking separately.

## Testing

- Full suite: 477 passed, 8 skipped (the 8 errors in test_real_media_samples are a pre-existing local-environment fixture timeout, identical on clean main)
- New tests: lock never stolen even with colliding hostname+pid, compare-and-expire heartbeat semantics (owner-only refresh, NX reclaim, never overwrites another holder), indefinite standby retry past the old 10-attempt cap, SCHEDULER_ENABLED gating, chunk-aware stuck-scan sweep (active chunks prevent false crash; positive control confirms real crashes still detected), UTC pin present in every connect_args including both init_app overrides, gunicorn bind parsing (default/single/list/blank)
- Runtime: booted gunicorn via the new conf with GUNICORN_BIND=[::]:5001 - listener came up on the IPv6 wildcard and served requests, SCHEDULER_ENABLED=false logged the skip and stayed out of lock arbitration; default boot unchanged
- webpack build passes