### PR TITLE
Ubuntu 26.04 base (ffmpeg 8, ImageMagick 7), Valkey 9, Postgres 18 (v2.7.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,28 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
+
+  # The ffmpeg/ImageMagick stderr parsers fail soft (zero events, no
+  # exceptions), so only running them against the image's actual tool
+  # versions catches regressions from a base-image bump.
+  image-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build Docker image
+      run: docker build -t pixelprobe-ci .
+
+    # -p no:timeout disables the per-test timeout marks (they assume fast
+    # local hardware); the job-level timeout-minutes is the hang backstop.
+    - name: Run real-media parser tests inside the image
+      run: |
+        docker run --rm -e SECRET_KEY=ci-test-secret pixelprobe-ci \
+          bash -c "pip install --no-cache-dir -r requirements-test.txt && \
+                   pip uninstall -y chardet 2>/dev/null; \
+                   pytest tests/test_real_media_samples.py -v -p no:cacheprovider -p no:timeout -o addopts=''"
+
+    - name: Verify tool versions in image
+      run: |
+        docker run --rm pixelprobe-ci bash -c "ffmpeg -version | head -1 && magick -version | head -1 && python --version"

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.7.0] - 2026-07-15
+
+### Breaking
+
+- **docker-compose.yml now defaults to PostgreSQL 18 (#67).** PostgreSQL data directories are not portable across major versions: an existing `postgres_data` volume created by PostgreSQL 15 will not start on the 18 image. Follow the new migration guide in docs/DOCKER_SETUP.md (dump on 15, restore into 18, refresh collation) BEFORE pulling the new compose file, or pin `postgres:15-alpine` to stay. The application itself works with PostgreSQL 15 through 18, so only the compose default is breaking - existing deployments that manage their own database are unaffected until they choose to migrate.
+
+### Changed
+
+- **Base image upgraded to Ubuntu 26.04 (#67).** FFmpeg 6.1.1 becomes 8.0.1 (faster demuxing/probing) and ImageMagick 6.9 becomes 7.1.2. The app pins Python 3.12 via deadsnakes and runs from a dedicated virtualenv (Ubuntu 26.04 ships 3.14, which psycopg2-binary has no wheels for yet). The image checker now invokes `magick` when available, falling back to `convert` on ImageMagick 6 systems, and the temporal-outlier probe uses `pts_time` (its `pkt_pts_time` field was removed in newer FFmpeg, which silently disabled that signal). Kernel header packages are purged from the final image, clearing the long tail of unfixable linux-libc-dev CVEs from scans.
+- **Task broker image switched from Redis 7 to Valkey 9 (#67).** Drop-in replacement: the compose service name, all redis:// URLs, and the wire protocol are unchanged, and the Valkey image ships redis-* compatibility symlinks. Valkey stays open source (BSD) while Redis moved away from it after 7.2.
+
+### Fixed
+
+- **Benign ImageMagick warning classification never matched.** The gates that classify PNG chunk and profile warnings as non-corruption checked for `@warning/png.c`, but ImageMagick (6 and 7 alike) emits `@ warning/png.c` with a space - so the benign-warning paths were unreachable and such files fell through to the generic error-keyword check. Verified against real ImageMagick output on both versions.
+
+### Added
+
+- **CI now builds the Docker image and runs the real-media parser tests inside it.** The FFmpeg/ImageMagick stderr parsers fail soft (a format change yields zero detections rather than an error), so unit tests on the runner's own tool versions cannot catch a base-image regression. The new job exercises corruption detection against the exact ffmpeg 8 / ImageMagick 7 binaries that ship in the image.
+- **PostgreSQL 15 to 18 migration guide** in docs/DOCKER_SETUP.md, including volume backup, restore verification, and collation refresh.
+
 ## [2.6.65] - 2026-07-15
 
 ### Fixed

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
-## [2.7.0] - 2026-07-15
+## [2.7.0] - 2026-07-16
 
 ### Breaking
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Closing the media viewer now actually stops playback.** The viewer modal was only hidden on close, so a playing video or audio file kept playing (and buffering) in the background. Closing now pauses the player and detaches its sources.
+- **Documentation accuracy audit.** All docs were checked against the codebase and corrected: removed endpoints that never existed (`/api/scan-all`, `/api/stats/summary`, `/api/scan/parallel-v2*`, `/api/export/csv`, `/api/cleanup`), fixed the example compose file (broken celery command, wrong healthcheck path, missing SECRET_KEY, fictional CELERY_WORKERS/REDIS_HOST vars), replaced the nonexistent Celery beat with the real APScheduler jobs, corrected pool sizes, session lifetime, task lists, chunking behavior, and rewrote PERFORMANCE_TUNING.md around env vars that actually exist. Example API clients now authenticate and call real endpoints. openapi.yaml: removed a duplicate path key and a nonexistent DELETE route, completed the schedule scan_type enum.
 - **Benign ImageMagick warning classification never matched.** The gates that classify PNG chunk and profile warnings as non-corruption checked for `@warning/png.c`, but ImageMagick (6 and 7 alike) emits `@ warning/png.c` with a space - so the benign-warning paths were unreachable and such files fell through to the generic error-keyword check. Verified against real ImageMagick output on both versions.
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,23 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Python and latest media tools
-# Ubuntu 24.04 includes:
-# - FFmpeg 6.1.1 (much newer than 22.04's 4.4.2)
-# - ImageMagick 6.9.13 (newer than 22.04's 6.9.11)
-# - Python 3.12 by default
+# Ubuntu 26.04 includes:
+# - FFmpeg 8.0.1 (vs 6.1.1 on 24.04)
+# - ImageMagick 7.1.2 (Q16; 'magick' CLI, 'convert' kept via alternatives)
+# - Python 3.14 by default; the app runs on 3.12 from deadsnakes (matches the
+#   tested CI matrix and available psycopg2-binary wheels)
 RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
-    # Python and pip
-    python3 \
-    python3-dev \
-    python3-venv \
-    python3-pip \
+    # Python 3.12 (deadsnakes)
+    python3.12 \
+    python3.12-dev \
+    python3.12-venv \
     # Node.js for frontend build \
     nodejs \
     npm \
@@ -24,11 +26,12 @@ RUN apt-get update && \
     libmagic1 \
     curl \
     wget \
-    # ImageMagick and dependencies (24.04 uses ImageMagick 7) \
+    # ImageMagick 7 (Q16, non-HDRI) and extra codecs \
     imagemagick \
-    libmagickcore-6.q16hdri-7-extra \
-    libmagickwand-6.q16hdri-7 \
-    # Image format libraries (updated versions in 24.04) \
+    imagemagick-7.q16 \
+    libmagickcore-7.q16-10-extra \
+    libmagickwand-7.q16-10 \
+    # Image format libraries \
     libjpeg-turbo8 \
     libjpeg-dev \
     libpng16-16t64 \
@@ -60,28 +63,31 @@ RUN apt-get update && \
     libfreetype6-dev \
     libfontconfig1 \
     libfontconfig1-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # pebble ships in the ubuntu:26.04 OCI rootfs (not dpkg-owned); unused
+    # here and its embedded Go deps carry unfixed HIGH CVEs, so drop it
+    && rm -rf /usr/bin/pebble /var/lib/pebble
 
-# Python 3.12 is already default in Ubuntu 24.04
-# Just create python symlink for compatibility
-RUN ln -s /usr/bin/python3 /usr/bin/python
+# All app Python runs from this venv (python/pip/gunicorn/celery resolve here).
+# A venv avoids pip 26+ conflicts with the system 3.14 dist-packages.
+RUN python3.12 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
-# Configure ImageMagick to allow all file formats and increase resource limits
-# Ubuntu 22.04 uses ImageMagick 6
-RUN sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml && \
-    sed -i 's/<policy domain="coder" rights="none" pattern="HEIC" \/>/<policy domain="coder" rights="read|write" pattern="HEIC" \/>/g' /etc/ImageMagick-6/policy.xml && \
-    sed -i 's/<policy domain="coder" rights="none" pattern="HEIF" \/>/<policy domain="coder" rights="read|write" pattern="HEIF" \/>/g' /etc/ImageMagick-6/policy.xml && \
-    sed -i 's/<policy domain="resource" name="memory" value=".*"\/>/<policy domain="resource" name="memory" value="2GiB"\/>/g' /etc/ImageMagick-6/policy.xml && \
-    sed -i 's/<policy domain="resource" name="map" value=".*"\/>/<policy domain="resource" name="map" value="4GiB"\/>/g' /etc/ImageMagick-6/policy.xml && \
-    sed -i 's/<policy domain="resource" name="disk" value=".*"\/>/<policy domain="resource" name="disk" value="8GiB"\/>/g' /etc/ImageMagick-6/policy.xml
+# Configure ImageMagick 7: raise resource limits for large media. The 26.04
+# default policy only sets disk=2GiB (no PDF/HEIC coder blocks to lift).
+RUN sed -i 's|<policy domain="resource" name="disk" value=".*"/>|<policy domain="resource" name="disk" value="8GiB"/>|' /etc/ImageMagick-7/policy.xml && \
+    sed -i 's|</policymap>|  <policy domain="resource" name="memory" value="2GiB"/>\n  <policy domain="resource" name="map" value="4GiB"/>\n</policymap>|' /etc/ImageMagick-7/policy.xml && \
+    # Fail the build if the seds silently matched nothing (policy format drift)
+    grep -q '"disk" value="8GiB"' /etc/ImageMagick-7/policy.xml && \
+    grep -q '"memory" value="2GiB"' /etc/ImageMagick-7/policy.xml && \
+    grep -q '"map" value="4GiB"' /etc/ImageMagick-7/policy.xml
 
 # Configure libpng and ImageMagick to handle benign PNG errors better
 # These environment variables tell libpng to be less strict
 ENV PNG_SKIP_SETJMP_CHECK=1
 ENV PNG_IGNORE_ADLER32=1
 
-# Set ImageMagick to be less verbose about warnings
-ENV MAGICK_CONFIGURE_PATH=/etc/ImageMagick-6
+ENV MAGICK_CONFIGURE_PATH=/etc/ImageMagick-7
 
 # Configure FFmpeg for optimal performance and compatibility
 # Set thread count for better performance
@@ -106,31 +112,36 @@ RUN ffmpeg -version && \
     ffmpeg -decoders 2>/dev/null | grep -E "(hevc|h264|h265|av1|vp9)" && \
     ffmpeg -encoders 2>/dev/null | grep -E "(libx264|libx265|libvpx)" && \
     echo "=== ImageMagick Version and Delegates ===" && \
-    convert -version && \
+    magick -version && \
     echo "=== ImageMagick Delegate Libraries ===" && \
-    convert -list delegate | head -30 && \
+    magick -list delegate | head -30 && \
     echo "=== ImageMagick Supported Formats ===" && \
-    identify -list format | grep -E "(JPEG|JPG|PNG|WEBP|GIF|TIFF|HEIC)" && \
+    magick identify -list format | grep -E "(JPEG|JPG|PNG|WEBP|GIF|TIFF|HEIC)" && \
     echo "=== Testing ImageMagick with sample images ===" && \
     # Test JPEG support \
-    convert -size 100x100 xc:white /tmp/test.jpg && \
-    identify -verbose /tmp/test.jpg | head -5 && \
+    magick -size 100x100 xc:white /tmp/test.jpg && \
+    magick identify -verbose /tmp/test.jpg | head -5 && \
     # Test PNG support \
-    convert -size 100x100 xc:white /tmp/test.png && \
-    identify -verbose /tmp/test.png | head -5 && \
+    magick -size 100x100 xc:white /tmp/test.png && \
+    magick identify -verbose /tmp/test.png | head -5 && \
     # Test WebP support \
-    convert -size 100x100 xc:white /tmp/test.webp && \
-    identify -verbose /tmp/test.webp | head -5 && \
+    magick -size 100x100 xc:white /tmp/test.webp && \
+    magick identify -verbose /tmp/test.webp | head -5 && \
     # Clean up test files \
     rm -f /tmp/test.jpg /tmp/test.png /tmp/test.webp && \
     echo "=== All image format tests passed ==="
 
 COPY requirements.txt .
-# Ubuntu 24.04 requires --break-system-packages for pip install in Docker
 # After install, remove chardet (pulled in by reportlab) -- its 7.x version fails
 # requests' version check (requires <6.0.0). Our app uses charset_normalizer instead.
-RUN pip install --no-cache-dir --break-system-packages --ignore-installed -r requirements.txt \
-    && pip uninstall -y chardet --break-system-packages 2>/dev/null; true
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip uninstall -y chardet 2>/dev/null; true
+
+# Build headers were only needed for pip C-extension builds above; linux-libc-dev
+# otherwise ships a stream of unfixed kernel-header CVEs the runtime never touches.
+RUN apt-get purge -y linux-libc-dev python3.12-dev 2>/dev/null; \
+    apt-get autoremove -y 2>/dev/null; \
+    rm -rf /var/lib/apt/lists/* /root/.cache
 
 COPY package.json webpack.config.js ./
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -32,20 +32,20 @@ PixelProbe detects corrupted video, image, and audio files across your media lib
 - **Rolling integrity queue**: Integrity checks sweep the library stalest-first in batches and resume where they left off; schedules can carry a per-run time budget so no single run monopolizes IO
 - **Scheduled automated scans**: Cron expressions or simple intervals for hands-free monitoring
 - **Smart exclusions**: Configure paths and file extensions to skip
-- **Phase-based scanning**: Discovery → Database → Validation workflow
+- **Phase-based scanning**: Discovery -> Database -> Validation workflow
 - **Bulk operations**: Rescan multiple files, deep analysis, batch actions
 
 ### Web Interface
-- Modern responsive design with dark/light theme support
+- Responsive design with dark/light theme support
 - Real-time scan progress with live polling updates
-- Advanced filtering and search capabilities
+- Filtering and search
 - Bulk file selection and management with shift-click range selection
 - Mobile-optimized touch interface
 - In-browser media file viewing and streaming
 - Detailed file corruption reports
 
 ### System Features
-- **PostgreSQL database**: Reliable ACID-compliant data storage
+- **PostgreSQL database**: Stores scan results, users, schedules, and history
 - **Redis-compatible task queue (Valkey)**: Background processing with Celery workers
 - **Docker deployment**: Multi-container architecture (web, workers, database, queue)
 - **REST API**: Full OpenAPI/Swagger documentation
@@ -60,7 +60,7 @@ PixelProbe detects corrupted video, image, and audio files across your media lib
 - **API token authentication**: Generate and manage tokens for programmatic access
 - **Session management**: Cookie-based sessions with CSRF protection, configurable timeout
 - **First-run setup wizard**: Secure admin account creation on initial deployment
-- **Audit logging**: Complete security event tracking
+- **Audit logging**: Security event tracking
 
 ## Screenshots
 
@@ -105,11 +105,7 @@ Full feature parity with a high-contrast dark theme. Preference persists across 
   <img src="docs/screenshots/mobile-dark-dashboard.png" alt="Mobile Dark Dashboard" width="300" style="margin: 10px">
 </div>
 
-The mobile interface is fully responsive and touch-optimized:
-- Adaptive layout that works on all screen sizes
-- Touch-friendly buttons and controls
-- Collapsible sidebar navigation
-- Card-based design for scan results on mobile
+The mobile layout has a collapsible sidebar and shows scan results as cards instead of a table.
 
 ### Advanced Features
 
@@ -321,12 +317,7 @@ export MEDIA_PATH=/mnt/all-media  # Contains subdirs: movies/, tv/, backup/
 
 ### API Documentation
 
-PixelProbe provides a REST API with OpenAPI/Swagger documentation.
-
-#### Interactive API Documentation
-- **Swagger UI**: Available at `/api-docs` when logged in
-- **OpenAPI Spec**: Full API specification with request/response schemas
-- **Try it out**: Test endpoints directly from the documentation
+Swagger UI is available at `/api-docs` when logged in. It includes the full OpenAPI spec with request/response schemas, and you can test endpoints directly from the page.
 
 #### Authentication Endpoints
 - `GET /api/auth/status` - Check authentication status

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ PixelProbe detects corrupted video, image, and audio files across your media lib
 
 ### System Features
 - **PostgreSQL database**: Reliable ACID-compliant data storage
-- **Redis-backed task queue**: Background processing with Celery workers
+- **Redis-compatible task queue (Valkey)**: Background processing with Celery workers
 - **Docker deployment**: Multi-container architecture (web, workers, database, queue)
 - **REST API**: Full OpenAPI/Swagger documentation
 - **Monitoring & Reports**: Real-time statistics, trend analytics, storage projections, PDF/JSON exports, complete audit trail
@@ -234,6 +234,13 @@ PixelProbe is available on Docker Hub as `ttlequals0/pixelprobe`:
 ## Requirements
 
 **Important**: PixelProbe requires PostgreSQL.
+
+**Upgrading to v2.7.0**: the bundled docker-compose.yml now defaults to
+PostgreSQL 18 and Valkey 9. The app works with PostgreSQL 15-18 and any
+Redis-compatible broker, but an existing PostgreSQL 15 data volume will not
+start on the 18 image - follow the migration guide in
+[docs/DOCKER_SETUP.md](docs/DOCKER_SETUP.md#postgresql-15-to-18-migration-required-for-v270)
+before switching, or pin `postgres:15-alpine` in your compose file.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Skip specific directories or file extensions. Changes take effect on the next sc
    
    # Edit .env file with your values
    SECRET_KEY=your-generated-secret-key-here
+   POSTGRES_PASSWORD=your-secure-database-password
    MEDIA_PATH=/path/to/your/actual/media/directory
    SCAN_PATHS=/media
    ```
@@ -250,6 +251,7 @@ PixelProbe uses environment variables for all configuration. Copy `.env.example`
 
 **Required Variables:**
 - `SECRET_KEY` - Secure secret key for Flask sessions
+- `POSTGRES_PASSWORD` - PostgreSQL password (compose refuses to start without it)
 - `MEDIA_PATH` - Host path to your media files (for Docker volume mounting)
 
 **Optional Variables:**
@@ -322,7 +324,7 @@ export MEDIA_PATH=/mnt/all-media  # Contains subdirs: movies/, tv/, backup/
 PixelProbe provides a REST API with OpenAPI/Swagger documentation.
 
 #### Interactive API Documentation
-- **Swagger UI**: Available at `/api/v1/docs` when logged in
+- **Swagger UI**: Available at `/api-docs` when logged in
 - **OpenAPI Spec**: Full API specification with request/response schemas
 - **Try it out**: Test endpoints directly from the documentation
 
@@ -489,9 +491,14 @@ for result in results:
    cd PixelProbe
    ```
 
-2. **Use development compose file**:
+2. **Run locally** (see [docs/INSTALLATION.md](docs/INSTALLATION.md) for the full manual setup):
    ```bash
-   docker-compose -f docker-compose.dev.yml up -d
+   python3 -m venv venv && source venv/bin/activate
+   pip install -r requirements.txt
+   # Terminal 1: web app
+   python app.py
+   # Terminal 2: Celery worker
+   python celery_worker.py
    ```
 
 ### Testing
@@ -527,7 +534,7 @@ If you encounter **"no such table: scan_results"** errors after upgrading:
 
 ```bash
 # Quick fix
-docker exec pixelprobe python tools/fix_database_schema.py
+docker exec pixelprobe-app python tools/fix_database_schema.py
 ```
 
 ### Common Issues
@@ -549,7 +556,7 @@ docker exec pixelprobe python tools/fix_database_schema.py
 
 ### Getting Help
 
-1. **Check logs first**: `docker logs pixelprobe` 
+1. **Check logs first**: `docker logs pixelprobe-app` 
 2. **Search existing issues**: [GitHub Issues](https://github.com/ttlequals0/PixelProbe/issues)
 3. **Create new issue**: Include logs and system info
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Skip specific directories or file extensions. Changes take effect on the next sc
 ## Documentation
 
 ### Installation & Setup
-- [Docker Setup Guide](docs/DOCKER_SETUP.md) - Complete Docker Compose setup with container explanations
+- [Docker Setup Guide](docs/DOCKER_SETUP.md) - Complete Docker Compose setup with container explanations, including the PostgreSQL 15 to 18 migration guide
 - [Installation Guide](docs/INSTALLATION.md) - Detailed installation instructions
 - [Configuration Guide](docs/CONFIGURATION.md) - Environment variables and configuration options
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,15 +22,22 @@
 
 services:
   # PostgreSQL database
+  # BREAKING (v2.7.0): default moved from postgres:15 to postgres:18. An
+  # existing postgres_data volume created by 15 will NOT start on 18 -- follow
+  # the migration guide in docs/DOCKER_SETUP.md (dump on 15, restore into 18)
+  # BEFORE pulling this compose file, or pin the image back to postgres:15-alpine.
   postgres:
-    image: postgres:15-alpine
+    image: postgres:18-alpine
     container_name: pixelprobe-postgres
     environment:
       POSTGRES_DB: pixelprobe
       POSTGRES_USER: pixelprobe
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # postgres:18+ images require the mount at /var/lib/postgresql (NOT
+      # .../data); data lives in a major-version subdirectory so future
+      # upgrades can use pg_upgrade --link
+      - postgres_data:/var/lib/postgresql
     # Not published to the host: app and worker reach it on the compose
     # network. For local debugging use: - "127.0.0.1:5432:5432"
     healthcheck:
@@ -41,20 +48,21 @@ services:
     networks:
       - pixelprobe-network
 
-  # Redis for Celery task broker
+  # Valkey (Redis-compatible) for Celery task broker. Drop-in replacement:
+  # the service name stays "redis" so all redis:// URLs are unchanged.
   # Performance settings for large task queues (file changes check with 1M+ files):
   # - REDIS_MAX_MEMORY: Total memory for task queue (default: 2gb, recommended: 1-4gb)
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:9-alpine
     container_name: pixelprobe-redis
     command: >
-      redis-server
+      valkey-server
       --maxmemory ${REDIS_MAX_MEMORY:-2gb}
       --maxmemory-policy noeviction
-    # Not published to the host: Redis has no auth and holds the broker plus
-    # the internal API secret. For local debugging use: - "127.0.0.1:6379:6379"
+    # Not published to the host: the broker has no auth and holds the
+    # internal API secret. For local debugging use: - "127.0.0.1:6379:6379"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -63,7 +71,7 @@ services:
 
   # PixelProbe application
   pixelprobe:
-    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.6.65}
+    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.7.0}
     container_name: pixelprobe-app
     environment:
       # Security
@@ -135,7 +143,7 @@ services:
 
   # P1 Celery Worker for distributed task processing
   celery-worker:
-    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.6.65}
+    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.7.0}
     container_name: pixelprobe-celery-worker
     command: python celery_worker.py
     environment:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-PixelProbe is a distributed media file corruption detection system built with a modular, layered architecture. The system uses Celery for distributed processing, Redis for message queuing, and PostgreSQL for persistent storage.
+PixelProbe is a distributed media file corruption detection system with a layered architecture. It uses Celery for distributed processing, Redis for message queuing, and PostgreSQL for persistent storage.
 
 ## System Components
 
@@ -195,7 +195,7 @@ api/
 
 ### Media Scanner (`media_checker.py`)
 
-The heart of the corruption detection system:
+The core corruption detection logic:
 
 ```python
 class PixelProbe:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,11 +107,19 @@ PixelProbe is a distributed media file corruption detection system built with a 
 **Key Modules**:
 ```
 api/
-├── scan_routes.py      # Scanning operations
-├── stats_routes.py     # Statistics and reports
-├── admin_routes.py     # Administrative functions
-├── export_routes.py    # Data export
-└── maintenance_routes.py # Cleanup operations
+├── scan_routes.py          # Scanning operations
+├── scan_routes_parallel.py # Parallel scan endpoints
+├── scan_launch.py          # Shared scan-launch helper
+├── stats_routes.py         # Statistics and reports
+├── admin_routes.py         # Administrative functions
+├── auth_routes.py          # Login, users, API tokens
+├── auth_decorator.py       # Authentication decorator
+├── export_routes.py        # Data export
+├── healthcheck_routes.py   # Healthcheck integration
+├── log_routes.py           # Log viewing and download
+├── notification_routes.py  # Notification providers/rules
+├── reports_routes.py       # Scan reports
+└── maintenance_routes.py   # Cleanup operations
 ```
 
 ### Service Layer
@@ -158,8 +166,10 @@ api/
 - Data model mapping
 
 **Key Repositories**:
-- `ScanRepository`: Scan result operations
-- `ConfigRepository`: Configuration management
+- `ScanRepository` / `ScanStateRepository`: Scan result and scan state operations
+- `ConfigurationRepository`: Configuration management
+- `IgnoredPatternRepository`: Ignored error patterns
+- `ScheduleRepository`: Scan schedules
 
 ### Data Layer
 
@@ -169,8 +179,15 @@ api/
 - `ScanResult`: File scan results
 - `ScanConfiguration`: Directory configurations
 - `IgnoredErrorPattern`: False positive patterns
+- `Exclusion`: Excluded paths and extensions
 - `ScanSchedule`: Scheduled scan configurations
 - `ScanState`: Current scan status
+- `ScanChunk`: Per-chunk progress for parallel scans
+- `ScanReport`: Completed scan reports
+- `CleanupState` / `FileChangesState`: Maintenance operation state
+- `HealthcheckConfig`: Healthcheck ping configuration
+- `User` / `APIToken`: Authentication
+- `NotificationProvider` / `NotificationRule`: Notifications
 - `LogEntry`: Persistent log storage with scan tagging
 - `AppConfig`: Application-level key-value configuration
 
@@ -208,12 +225,22 @@ Manages scheduled scans using APScheduler:
 
 ```python
 class MediaScheduler:
-    def schedule_scan(self, cron_expression, scan_config):
-        # Create scheduled job
-        
-    def run_scheduled_scan(self, job_id):
-        # Execute scan with configuration
+    def create_schedule(self, name, cron_expression, scan_paths=None, scan_type='normal'):
+        # Create scheduled scan
+
+    def update_schedule(self, schedule_id, **kwargs):
+        # Update an existing schedule
+
+    def delete_schedule(self, schedule_id):
+        # Remove a schedule
+
+    def _run_scheduled_scan(self, schedule_id):
+        # Execute scan with the schedule's configuration
 ```
+
+A `db_schedule_sync` job (added v2.6.63) re-syncs saved schedules from the database
+every 60 seconds via a fingerprint comparison, so create/update/delete in gunicorn
+workers takes effect in the scheduler process without a restart.
 
 ## Data Flow
 
@@ -243,14 +270,15 @@ Worker1  Worker2  Worker3  Worker4  Worker5         Worker1  Worker2  Worker3  W
 ### Real-time Updates
 
 ```
-Celery Worker → Redis (scan_progress:{id}) → API Status Endpoint → Client
-                       ↓ (on completion)
-                  PostgreSQL (final sync)
+Chunk task → PostgreSQL (scan_state + scan_chunks, every 100 files or 60s)
+        ↓ (mirrored on each write)
+   Redis (scan_progress:{id}) → API Status Endpoint → Client
 ```
 
-Progress counters are written to Redis on every file processed. The scan-status API
-reads from Redis for active scans (fresh data) and falls back to PostgreSQL for
-completed/inactive scans. A final Redis-to-DB sync occurs at scan completion.
+PostgreSQL is the source of truth for progress. Chunk tasks commit progress at batch
+boundaries (every 100 files) or at least every 60 seconds, and mirror each write to
+Redis for low-latency UI polling. The scan-status API reads Redis first with a
+database fallback.
 
 ## Security Architecture
 
@@ -384,9 +412,9 @@ Load Balancer / Nginx
 ## Technology Stack
 
 ### Backend
-- **Framework**: Flask 2.3.3
-- **Database**: SQLAlchemy 2.0.21
-- **Scheduler**: APScheduler 3.10.4
+- **Framework**: Flask 3.1.3
+- **Database**: SQLAlchemy 2.0.41
+- **Scheduler**: APScheduler 3.11.0
 - **Security**: Flask-Limiter, Flask-WTF
 
 ### Scanner Tools

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -321,8 +321,8 @@ Request → Rate Limiter → CSRF Check → Input Validation
 Docker Compose
     ├── pixelprobe-app (Gunicorn + Flask)
     ├── pixelprobe-celery-worker (Celery)
-    ├── pixelprobe-postgres (PostgreSQL 15)
-    └── pixelprobe-redis (Redis 7)
+    ├── pixelprobe-postgres (PostgreSQL 18)
+    └── pixelprobe-redis (Valkey 9)
 ```
 
 ### Production (with reverse proxy)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -145,14 +145,14 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:15-alpine
+    image: postgres:18-alpine
     container_name: pixelprobe-postgres
     environment:
       POSTGRES_DB: pixelprobe
       POSTGRES_USER: pixelprobe
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U pixelprobe"]
       interval: 10s
@@ -160,11 +160,11 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:9-alpine
     container_name: pixelprobe-redis
-    command: redis-server --maxmemory ${REDIS_MAX_MEMORY:-2gb} --maxmemory-policy noeviction
+    command: valkey-server --maxmemory ${REDIS_MAX_MEMORY:-2gb} --maxmemory-policy noeviction
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -373,7 +373,7 @@ For best performance:
 ```yaml
 pixelprobe:
   volumes:
-    - /mnt/ssd/postgres_data:/var/lib/postgresql/data  # SSD for database
+    - /mnt/ssd/postgres_data:/var/lib/postgresql  # SSD for database
     - /mnt/hdd/media:/media:ro                          # HDD OK for media
   tmpfs:
     - /tmp:size=1G                                      # tmpfs for temp files

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # PixelProbe Configuration Guide
 
-Complete reference for all PixelProbe configuration options, environment variables, and performance tuning.
+Reference for PixelProbe environment variables and performance tuning.
 
 ## Table of Contents
 
@@ -580,13 +580,7 @@ Tokens support optional expiration dates.
 
 ## Configuration Best Practices
 
-1. **Start Conservative**: Begin with default settings and increase gradually
-2. **Monitor Resources**: Use `docker stats` to monitor CPU/memory usage
-3. **Test Changes**: Test configuration changes on a subset of files first
-4. **Document Settings**: Keep notes on what works for your environment
-5. **Regular Backups**: Backup database and configuration regularly
-6. **Security First**: Use strong passwords and keep SECRET_KEY secure
-7. **Update Regularly**: Pull latest images for bug fixes and improvements
+Start with the defaults and raise `MAX_WORKERS` and `CELERY_CONCURRENCY` gradually, watching `docker stats` for CPU and memory pressure. Back up the database and `.env` before upgrades, use strong passwords, and keep `SECRET_KEY` secret.
 
 ## Examples
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -35,6 +35,8 @@ All configuration is done via environment variables, either in `.env` file or di
 | `POSTGRES_DB` | `pixelprobe` | Database name |
 | `POSTGRES_USER` | `pixelprobe` | Database username |
 | `POSTGRES_PASSWORD` | (required) | Database password |
+| `DB_POOL_SIZE` | `5` | SQLAlchemy base connection pool size per process |
+| `DB_MAX_OVERFLOW` | `10` | Extra SQLAlchemy connections when the pool is exhausted |
 | `DATABASE_ECHO` | `false` | Enable SQL query logging (debug) |
 
 ### Application Variables
@@ -119,13 +121,12 @@ CLEANUP_SCHEDULE=interval:days:7             # Every 7 days
 | `SCAN_OUTPUT_RETENTION_DAYS` | `30` | Days before archiving scan outputs (currently disabled) |
 | `REPORT_RETENTION_DAYS` | `90` | Days before deleting old reports |
 | `SCAN_STATE_RETENTION_DAYS` | `7` | Days before deleting completed scan states |
-| `LOG_RETENTION_DAYS` | `30` | Days before deleting old log entries (configurable via UI) |
 
 **Data Retention Notes:**
-- Automated cleanup runs daily via Celery Beat
+- Automated cleanup runs daily via the built-in MediaScheduler (APScheduler): data retention at 04:00, log retention at 03:00
 - `SCAN_OUTPUT_RETENTION_DAYS` is currently not used (scan results kept forever)
 - Configurable via environment variables for future flexibility
-- `LOG_RETENTION_DAYS` default is stored in the `app_configs` database table and can be changed via the UI (System > View Logs) or API (`PUT /api/logs/retention`)
+- Log retention days is not an environment variable: it is stored in the `app_configs` database table (default 30) and changed via the UI (System > View Logs) or API (`PUT /api/logs/retention`)
 
 ### Monitoring Variables (Future)
 
@@ -277,15 +278,15 @@ Configured in `config.py`:
 
 ```python
 SQLALCHEMY_ENGINE_OPTIONS = {
-    'pool_size': 20,           # Base connection pool size
+    'pool_size': 5,            # Base pool size per process (DB_POOL_SIZE)
     'pool_pre_ping': True,     # Test connections before use
     'pool_recycle': 3600,      # Recycle connections after 1 hour
-    'max_overflow': 40,        # Additional connections when pool exhausted
+    'max_overflow': 10,        # Extra connections when pool exhausted (DB_MAX_OVERFLOW)
     'pool_timeout': 30,        # Timeout waiting for connection
 }
 ```
 
-**Total Connections:** 20 (base) + 40 (overflow) + MAX_WORKERS = 60 + MAX_WORKERS
+**Total Connections:** 4 gunicorn workers x (5 base + 10 overflow) = 60 max for the web app, plus Celery prefork children and ~MAX_WORKERS checker connections
 
 **PostgreSQL max_connections:**
 - Default: 100 connections
@@ -434,25 +435,18 @@ CELERY_CONCURRENCY=8
 
 ### Task Prioritization
 
-Celery queues and priorities are automatically configured:
+All tasks run on a single queue named `pixelprobe`. Priorities (0 = highest, 9 = lowest) are set per task:
 
-- **Default Queue**: Normal scans (priority 5)
-- **Integrity Queue**: Integrity checks (priority 7)
-- **Cleanup Queue**: Database cleanup (priority 6)
-- **Retention Queue**: Data retention (priority 9)
+- **Default**: Tasks without an explicit priority (priority 5)
+- **Scan tasks**: High priority (priority 3)
+- **Maintenance tasks**: File changes checks, cleanup (priority 7, background)
 
-### Beat Schedule (Automated Tasks)
+### Scheduled Maintenance (Automated Tasks)
 
-Celery Beat runs scheduled tasks daily:
+There is no Celery Beat process. Scheduled maintenance runs in the built-in MediaScheduler (APScheduler, inside the Celery worker container by default):
 
-```python
-# Runs at 2 AM daily
-'data-retention-cleanup': {
-    'task': 'pixelprobe.tasks.run_retention_cleanup',
-    'schedule': crontab(hour=2, minute=0),
-    'options': {'queue': 'retention', 'priority': 9}
-}
-```
+- Log retention cleanup: daily at 03:00
+- Data retention cleanup: daily at 04:00
 
 ## Data Retention Configuration
 
@@ -533,11 +527,12 @@ Copy the output to `SECRET_KEY` in `.env`.
 Session settings are configured in Flask:
 
 ```python
-# Session timeout (default: 30 days)
-PERMANENT_SESSION_LIFETIME = timedelta(days=30)
+# Session timeout (24 hours)
+PERMANENT_SESSION_LIFETIME = 86400
 
 # Session cookie settings
-SESSION_COOKIE_SECURE = True   # HTTPS only (production)
+SESSION_COOKIE_SECURE = True   # HTTPS only; default true. Plain-HTTP LAN
+                               # deployments must set SESSION_COOKIE_SECURE=false
 SESSION_COOKIE_HTTPONLY = True # Prevent JavaScript access
 SESSION_COOKIE_SAMESITE = 'Lax' # CSRF protection
 ```

--- a/docs/DOCKER_SETUP.md
+++ b/docs/DOCKER_SETUP.md
@@ -1,8 +1,6 @@
 # Docker Setup Guide
 
-## Quick Start
-
-This guide explains the Docker Compose setup for PixelProbe and what each container does.
+The Docker Compose setup for PixelProbe and what each container does.
 
 ## Container Overview
 
@@ -193,46 +191,20 @@ REDIS_MAX_MEMORY=2gb
 ## Container Responsibilities
 
 ### PostgreSQL Container
-- **What it does**: Stores all persistent data
-- **Stores**:
-  - Scan results and metadata
-  - File corruption status
-  - User configurations
-  - Scan history
-  - Scheduled scan settings
-- **Why needed**: Provides reliable, ACID-compliant data storage
+
+Stores all persistent data: scan results and metadata, file corruption status, user configurations, scan history, and schedule settings.
 
 ### Redis Container
-- **What it does**: Manages task queue and caching
-- **Handles**:
-  - Celery task messages
-  - Worker coordination
-  - Result caching
-  - Progress updates
-- **Why needed**: Enables parallel processing and real-time updates
+
+Carries the Celery task queue: task messages, worker coordination, result caching, and progress updates.
 
 ### Web Application Container
-- **What it does**: Serves the user interface and API
-- **Provides**:
-  - Web dashboard at port 5000
-  - REST API endpoints
-  - User authentication
-  - Real-time scan progress
-  - Scheduled scan management
-- **Why needed**: Primary interface for users to interact with the system
+
+Serves the dashboard and REST API on port 5000, handles user authentication, reports real-time scan progress, and manages scheduled scans.
 
 ### Celery Worker Container
-- **What it does**: Performs the actual file scanning
-- **Executes**:
-  - Media file corruption detection
-  - Parallel file discovery
-  - Batch processing
-  - Cleanup operations
-- **Tools used**:
-  - FFmpeg for video/audio
-  - ImageMagick for images
-  - Python PIL for additional image processing
-- **Why needed**: Handles CPU-intensive scanning tasks in parallel
+
+Does the actual scanning: corruption detection, parallel file discovery, batch processing, and cleanup. It runs FFmpeg for video/audio, and ImageMagick plus Python PIL for images.
 
 ## Scaling Options
 

--- a/docs/DOCKER_SETUP.md
+++ b/docs/DOCKER_SETUP.md
@@ -23,14 +23,14 @@ version: '3.8'
 services:
   # PostgreSQL Database - Stores all scan results and metadata
   postgres:
-    image: postgres:15-alpine
+    image: postgres:18-alpine
     container_name: pixelprobe-postgres
     environment:
       POSTGRES_DB: pixelprobe
       POSTGRES_USER: pixelprobe
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - "5432:5432"  # Optional: expose for external tools
     healthcheck:
@@ -42,13 +42,13 @@ services:
 
   # Redis - Message broker for Celery task queue
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:9-alpine
     container_name: pixelprobe-redis
-    command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
+    command: valkey-server --maxmemory 256mb --maxmemory-policy allkeys-lru
     ports:
       - "6379:6379"  # Optional: expose for monitoring
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -410,3 +410,62 @@ tar -czf pixelprobe_config_$(date +%Y%m%d).tar.gz docker-compose.yml .env
 4. Pull new image: `docker-compose pull`
 5. Start containers: `docker-compose up -d`
 6. Check logs: `docker-compose logs -f`
+
+## PostgreSQL 15 to 18 Migration (required for v2.7.0+)
+
+Starting with v2.7.0 the compose file defaults to `postgres:18-alpine`.
+PostgreSQL data directories are NOT portable across major versions: an
+existing `postgres_data` volume created by PostgreSQL 15 will refuse to start
+on the 18 image (the container crash-loops with a version mismatch error).
+Migrate BEFORE switching to the new compose file. If you are not ready to
+migrate, pin `image: postgres:15-alpine` in your compose file - the app works
+with both versions.
+
+Also note: the postgres:18+ Docker images changed the expected volume mount
+point from `/var/lib/postgresql/data` to `/var/lib/postgresql` (data now lives
+in a major-version subdirectory so future upgrades can use `pg_upgrade
+--link`). The 18 image refuses to start with a volume mounted at the old
+`/data` path. The bundled docker-compose.yml already uses the new mount; if
+you maintain your own compose file, update the postgres volume line to
+`- postgres_data:/var/lib/postgresql`.
+
+Downtime for the migration is roughly the dump plus restore time (a few
+minutes for typical libraries).
+
+```bash
+# 1. Dump while the OLD stack is still running
+DUMP=pixelprobe_pg15_$(date +%Y%m%d).sql.gz
+docker exec pixelprobe-postgres pg_dump -U pixelprobe pixelprobe | gzip > "$DUMP"
+
+# 2. Stop the stack
+docker-compose down
+
+# 3. Keep the old volume as a fallback (rename instead of delete)
+docker volume create pixelprobe_postgres_data_pg15_backup
+docker run --rm -v pixelprobe_postgres_data:/from -v pixelprobe_postgres_data_pg15_backup:/to alpine sh -c "cp -a /from/. /to/"
+docker volume rm pixelprobe_postgres_data
+
+# 4. NOW switch to the v2.7.0 compose file (postgres:18 image and the new
+#    /var/lib/postgresql volume mount) - e.g. git pull or edit your copy
+
+# 5. Start ONLY postgres on the new compose file (creates a fresh v18 volume)
+docker-compose up -d postgres
+# wait for: docker exec pixelprobe-postgres pg_isready -U pixelprobe
+
+# 6. Restore the dump
+gunzip < "$DUMP" | docker exec -i pixelprobe-postgres psql -U pixelprobe pixelprobe
+
+# 7. Refresh collation metadata (avoids "collation version mismatch" warnings)
+docker exec pixelprobe-postgres psql -U pixelprobe -d pixelprobe -c "ALTER DATABASE pixelprobe REFRESH COLLATION VERSION;"
+docker exec pixelprobe-postgres psql -U pixelprobe -d pixelprobe -c "REINDEX DATABASE pixelprobe;"
+
+# 8. Start the rest of the stack and verify
+docker-compose up -d
+# sanity check: row counts should match your pre-migration numbers
+docker exec pixelprobe-postgres psql -U pixelprobe -d pixelprobe -c "SELECT COUNT(*) FROM scan_results;"
+```
+
+Note: your compose project name may prefix the volume (e.g.
+`pixelprobe_postgres_data`); check with `docker volume ls`. Once you have
+verified the app against PostgreSQL 18, the `_pg15_backup` volume and the
+dump file can be deleted.

--- a/docs/DOCKER_SETUP.md
+++ b/docs/DOCKER_SETUP.md
@@ -18,8 +18,6 @@ PixelProbe uses 4 main containers:
 ## Complete Docker Compose File
 
 ```yaml
-version: '3.8'
-
 services:
   # PostgreSQL Database - Stores all scan results and metadata
   postgres:
@@ -28,11 +26,11 @@ services:
     environment:
       POSTGRES_DB: pixelprobe
       POSTGRES_USER: pixelprobe
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
     volumes:
       - postgres_data:/var/lib/postgresql
-    ports:
-      - "5432:5432"  # Optional: expose for external tools
+    # Not published to the host: app and worker reach it on the compose
+    # network. For local debugging use: - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U pixelprobe"]
       interval: 10s
@@ -40,13 +38,18 @@ services:
       retries: 5
     restart: unless-stopped
 
-  # Redis - Message broker for Celery task queue
+  # Valkey (Redis-compatible) - Message broker for Celery task queue.
+  # noeviction is required: an eviction policy like allkeys-lru could
+  # silently drop queued task messages under memory pressure.
   redis:
     image: valkey/valkey:9-alpine
     container_name: pixelprobe-redis
-    command: valkey-server --maxmemory 256mb --maxmemory-policy allkeys-lru
-    ports:
-      - "6379:6379"  # Optional: expose for monitoring
+    command: >
+      valkey-server
+      --maxmemory ${REDIS_MAX_MEMORY:-2gb}
+      --maxmemory-policy noeviction
+    # Not published to the host: the broker has no auth. For local
+    # debugging use: - "127.0.0.1:6379:6379"
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
@@ -56,26 +59,33 @@ services:
 
   # Main Web Application - Serves UI and API
   pixelprobe:
-    image: ttlequals0/pixelprobe:latest
-    container_name: pixelprobe-web
+    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.7.0}
+    container_name: pixelprobe-app
     ports:
       - "5000:5000"  # Required: web interface access
     environment:
+      # Security
+      SECRET_KEY: ${SECRET_KEY}
+
+      # Scheduler runs in celery-worker; keep the web container out of the
+      # scheduler lock entirely (set to "true" only in single-container setups)
+      SCHEDULER_ENABLED: "false"
+
       # Database Configuration
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
       POSTGRES_DB: pixelprobe
       POSTGRES_USER: pixelprobe
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       
-      # Redis Configuration
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
+      # Celery Configuration
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       
       # Application Settings
-      SECRET_KEY: ${SECRET_KEY}
+      SCAN_PATHS: /media,/photos,/videos
+      EXCLUDED_PATHS: ${EXCLUDED_PATHS:-}
+      EXCLUDED_EXTENSIONS: ${EXCLUDED_EXTENSIONS:-.txt,.log,.md}
       MAX_WORKERS: 10
       BATCH_SIZE: 100
       OUTPUT_ROTATION_ENABLED: true
@@ -93,35 +103,42 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 120s  # migrations run before workers serve requests
     restart: unless-stopped
 
   # Celery Worker - Processes scan tasks in parallel
   celery-worker:
-    image: ttlequals0/pixelprobe:latest
-    container_name: pixelprobe-celery
-    command: celery -A celery_app worker --loglevel=info --concurrency=8
+    image: ttlequals0/pixelprobe:${PIXELPROBE_VERSION:-2.7.0}
+    container_name: pixelprobe-celery-worker
+    command: python celery_worker.py
     environment:
+      # Security (config.py refuses to start without SECRET_KEY)
+      SECRET_KEY: ${SECRET_KEY}
+
       # Database Configuration
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
       POSTGRES_DB: pixelprobe
       POSTGRES_USER: pixelprobe
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       
-      # Redis Configuration
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
+      # Celery Configuration
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
+      CELERY_LOG_LEVEL: ${CELERY_LOG_LEVEL:-INFO}
+      CELERY_CONCURRENCY: ${CELERY_CONCURRENCY:-4}  # Concurrent Celery tasks
       
       # Worker Settings
-      CELERY_WORKERS: 8  # Number of parallel workers
       MAX_WORKERS: 10
-      BATCH_SIZE: 100
+      
+      # Scan configuration (required for the scheduler, which runs here)
+      SCAN_PATHS: /media,/photos,/videos
+      EXCLUDED_PATHS: ${EXCLUDED_PATHS:-}
+      EXCLUDED_EXTENSIONS: ${EXCLUDED_EXTENSIONS:-.txt,.log,.md}
       
       # Timezone (optional)
       TZ: America/New_York
@@ -167,9 +184,10 @@ SECRET_KEY=your-secret-key-for-sessions-here
 
 # Optional settings
 TZ=America/New_York
-CELERY_WORKERS=8
+CELERY_CONCURRENCY=4
 MAX_WORKERS=10
 BATCH_SIZE=100
+REDIS_MAX_MEMORY=2gb
 ```
 
 ## Container Responsibilities
@@ -233,7 +251,7 @@ Or increase concurrency in a single container:
 
 ```yaml
 environment:
-  CELERY_WORKERS: 16  # Increase from 8 to 16 workers
+  CELERY_CONCURRENCY: 8  # Increase from the default 4 concurrent tasks
 ```
 
 ### Performance Tuning
@@ -242,11 +260,11 @@ Adjust these settings based on your system:
 
 | Setting | Default | Description | Recommendation |
 |---------|---------|-------------|----------------|
-| CELERY_WORKERS | 8 | Parallel workers per container | Set to CPU cores |
+| CELERY_CONCURRENCY | 4 | Concurrent Celery tasks per container | 8-12 (tasks are mostly ffmpeg/imagemagick subprocess-bound) |
 | MAX_WORKERS | 10 | Max concurrent operations | 1.5x CPU cores |
 | BATCH_SIZE | 100 | Files per processing chunk | 50-200 based on file sizes |
 | postgres memory | - | Database cache | 25% of system RAM |
-| redis maxmemory | 256mb | Cache size | 512mb-1gb for large libraries |
+| REDIS_MAX_MEMORY | 2gb | Task queue memory | 1-4gb for large libraries |
 
 ## Volume Mounts
 
@@ -346,12 +364,12 @@ docker-compose down
 
 ### Check Worker Status
 ```bash
-docker exec pixelprobe-celery celery -A celery_app inspect active
+docker exec pixelprobe-celery-worker celery -A pixelprobe.celery_config inspect active
 ```
 
 ### View Queue Length
 ```bash
-docker exec pixelprobe-redis redis-cli LLEN celery
+docker exec pixelprobe-redis valkey-cli LLEN pixelprobe
 ```
 
 ### Database Connections
@@ -364,7 +382,7 @@ docker exec pixelprobe-postgres psql -U pixelprobe -c "SELECT count(*) FROM pg_s
 ### Workers Not Processing
 1. Check Redis is running: `docker-compose ps redis`
 2. Check worker logs: `docker-compose logs celery-worker`
-3. Verify queue: `docker exec pixelprobe-redis redis-cli LLEN celery`
+3. Verify queue: `docker exec pixelprobe-redis valkey-cli LLEN pixelprobe`
 
 ### Database Connection Issues
 1. Check PostgreSQL is healthy: `docker-compose ps postgres`
@@ -372,10 +390,10 @@ docker exec pixelprobe-postgres psql -U pixelprobe -c "SELECT count(*) FROM pg_s
 3. Check password in `.env` file
 
 ### High Memory Usage
-1. Reduce CELERY_WORKERS
+1. Reduce CELERY_CONCURRENCY
 2. Lower BATCH_SIZE
 3. Enable OUTPUT_ROTATION_ENABLED
-4. Increase redis maxmemory limit
+4. Increase REDIS_MAX_MEMORY limit
 
 ## Security Considerations
 

--- a/docs/FIX_INCOMPLETE_SCANS.md
+++ b/docs/FIX_INCOMPLETE_SCANS.md
@@ -48,6 +48,3 @@ AND (scan_date IS NULL OR scan_output IS NULL OR scan_output = '' OR scan_output
 Once files are reset to 'pending':
 1. Run a normal scan - it will pick up all pending files
 2. Or run a "Force Scan Pending" to specifically target these files
-
-## Prevention
-This issue is fixed in v2.2.59 and later versions.

--- a/docs/FIX_INCOMPLETE_SCANS.md
+++ b/docs/FIX_INCOMPLETE_SCANS.md
@@ -14,7 +14,7 @@ Due to the chunk query bug in versions before v2.2.59, some files were marked as
 ### Option 1: Use the API Endpoint
 ```bash
 # Reset all incomplete scans
-curl -X POST https://pixelprobe.ttlequals0.com/api/reset-incomplete-scans \
+curl -X POST http://your-server/api/reset-incomplete-scans \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # PixelProbe Installation Guide
 
-This guide provides complete installation instructions for PixelProbe, covering both Docker (recommended) and manual installation methods.
+How to install PixelProbe, either with Docker (recommended) or manually.
 
 ## Table of Contents
 
@@ -161,7 +161,7 @@ docker-compose logs -f pixelprobe-celery-worker
 
 ## Manual Installation
 
-For advanced users who prefer manual installation without Docker.
+For running PixelProbe without Docker.
 
 ### 1. Clone the Repository
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -42,14 +42,18 @@ sudo apt-get update
 sudo apt-get install -y \
     python3 python3-dev python3-venv python3-pip \
     ffmpeg imagemagick \
-    postgresql-15 redis-server \
+    postgresql redis-server \
     git curl wget
 ```
 
+PixelProbe supports PostgreSQL 15 through 18; the distro default is fine. For
+PostgreSQL 18 on releases that ship an older version, use the
+[PGDG apt repository](https://www.postgresql.org/download/linux/ubuntu/).
+
 **macOS:**
 ```bash
-brew install python@3.11 ffmpeg imagemagick postgresql@15 redis git
-brew services start postgresql@15
+brew install python@3.12 ffmpeg imagemagick postgresql@18 redis git
+brew services start postgresql@18
 brew services start redis
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -248,16 +248,7 @@ source venv/bin/activate
 python celery_worker.py
 ```
 
-### 9. Start Celery Beat (Optional - for scheduled scans)
-
-In a new terminal (with venv activated):
-
-```bash
-source venv/bin/activate
-celery -A celery_config beat --loglevel=info
-```
-
-### 10. Start Web Application
+### 9. Start Web Application
 
 In a new terminal (with venv activated):
 
@@ -310,13 +301,16 @@ You should see the login page. Log in with:
 ### 2. Check API Health
 
 ```bash
-curl http://localhost:5000/health
+curl http://localhost:5000/healthz
 ```
 
 Should return:
 ```json
-{"status": "healthy", "database": "connected", "redis": "connected"}
+{"status": "ok", "version": "2.7.0"}
 ```
+
+Note: `/health` also exists but requires authentication; `/healthz` is the
+unauthenticated liveness probe used by the container healthcheck.
 
 ### 3. Check Celery Worker
 
@@ -330,10 +324,16 @@ docker logs pixelprobe-celery-worker
 You should see:
 ```
 [tasks]
-  . pixelprobe.tasks.cleanup_database_task
-  . pixelprobe.tasks.file_changes_scan_task
-  . pixelprobe.tasks.integrity_check_task
-  . pixelprobe.tasks.scan_directory_task
+  . pixelprobe.tasks.calculate_file_hash_task
+  . pixelprobe.tasks.check_file_exists_task
+  . pixelprobe.tasks.health_check_task
+  . pixelprobe.tasks.reload_schedules_task
+  . pixelprobe.tasks.run_retention_cleanup
+  . pixelprobe.tasks.scan_files_task
+  . pixelprobe.tasks.scan_media_task
+  . pixelprobe.tasks_parallel.discover_directory_task
+  . pixelprobe.tasks_parallel.parallel_scan_orchestrator
+  . pixelprobe.tasks_parallel.process_chunk_task
 ```
 
 ### 4. Test a Simple Scan
@@ -352,7 +352,7 @@ After successful installation:
 2. **Performance Tuning**: Adjust MAX_WORKERS and other settings based on your system
 3. **Schedule Automated Scans**: Set up periodic scans in the web interface under Tools > Schedules
 4. **Configure Exclusions**: Add paths and extensions to exclude under Tools > Exclusions
-5. **Review API Documentation**: Access Swagger docs at /api/v1/docs (after login)
+5. **Review API Documentation**: Access the API docs at /api-docs (after login)
 
 ## Upgrade Process
 
@@ -385,7 +385,7 @@ git pull origin main
 pip install -r requirements.txt --upgrade
 
 # Restart all services
-# (Stop and restart app.py, celery_worker.py, celery beat)
+# (Stop and restart app.py and celery_worker.py)
 ```
 
 ## Troubleshooting

--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -3,63 +3,56 @@
 ## Environment Variables for Performance
 
 ### Scanning Performance
-- `MAX_SCAN_WORKERS=4` - Number of parallel scan workers (default: 4)
-- `BATCH_COMMIT_SIZE=50` - Number of scan results to commit in one batch (default: 50)
-- `RESET_BATCH_SIZE=500` - Batch size for reset operations (default: 500)
-- `SYSTEM_INFO_TIMEOUT=30` - Timeout for system info operations (default: 30 seconds)
+- `CELERY_CONCURRENCY=4` - Number of Celery worker processes (default: 4). This is the main scan-throughput knob: scans are split into chunks that fan out across these workers.
+- `MAX_WORKERS=10` - ThreadPoolExecutor threads for parallel file validation within a scan task (default: 10). Distinct from Celery concurrency.
+- `BATCH_SIZE=100` - Number of scan results committed per batch (default: 100).
+- `FREEZE_DETECTION_ENABLED=true` - Toggle video freeze-frame detection (default: true). Disabling it speeds up video scans at the cost of coverage.
+- `time_budget_minutes` - Per-schedule setting on file-changes schedules. Caps how long a rolling integrity check runs; the next run resumes where the last one stopped.
 
 ### Database Performance
 - `DATABASE_URL=postgresql://user:pass@host/pixelprobe` - Database connection string
+- `DB_POOL_SIZE=5` - SQLAlchemy connection pool size per process (default: 5)
+- `DB_MAX_OVERFLOW=10` - Extra connections beyond the pool (default: 10)
 - PostgreSQL connection pooling is automatically configured with:
   - Pool pre-ping: enabled
-  - Pool recycle: 300 seconds
-  - Connection timeout: 15 seconds
+  - Pool recycle: 3600 seconds
+  - Pool timeout: 30 seconds
+  - Connection timeout: 10 seconds
 
-## Performance Improvements Made
+Keep pool math under PostgreSQL `max_connections` (default 100): 4 gunicorn workers x (5 + 10) = 60 max for the web app, plus Celery children and checker connections.
 
-### 1. Database Indexes
-Added indexes on frequently queried columns (created automatically on startup):
-- `scan_status` - For filtering by scan status
-- `scan_date` - For sorting by scan date
-- `is_corrupted` - For filtering corrupted files
-- `marked_as_good` - For filtering marked files
-- `file_hash` - For duplicate detection
-- `last_modified` - For change detection
+### Redis
+- `REDIS_MAX_MEMORY=2gb` - Memory limit for the Redis/Valkey task queue (default: 2gb, recommended: 1-4gb).
 
-Indexes are created automatically when the application starts. For existing installations, you can also run `python create_indexes.py` manually.
+## Chunk Sizing
 
-### 2. Batch Processing Optimization
-- Reduced batch size from 1000 to 500 for better memory usage
-- Added configurable batch sizes via environment variables
-- Improved commit frequency to prevent long-running transactions
+Scans are divided into path-range chunks automatically; chunk size adapts to the number of pending files and is not configurable:
 
-### 3. Memory Usage Optimization
-- Truncated scan output to prevent memory issues (max 100 lines, 5000 chars)
-- Used bulk database operations instead of loading all records into memory
-- Optimized reset operations to use database-level updates
+| Pending files | Chunk size |
+|---------------|------------|
+| <= 100 | 1 chunk (all files) |
+| <= 1,000 | 100 files/chunk |
+| <= 10,000 | 500 files/chunk |
+| > 10,000 | 1,000 files/chunk |
 
-### 4. Query Optimization
-- Replaced individual record updates with bulk operations
-- Added proper indexing for common query patterns
-- Optimized reset operations to use single UPDATE statements
+## Database Indexes
+
+Indexes on frequently queried columns (`scan_status`, `scan_date`, `is_corrupted`, `marked_as_good`, `file_hash`, `last_modified`) are created automatically by the startup migrations. No manual step is needed; `scripts/create_indexes.py` is a legacy script kept for reference.
 
 ## Performance Monitoring
 
 ### Memory Usage
-Monitor the container's memory usage during resets:
 ```bash
 docker stats pixelprobe
 ```
 
 ### Database Performance
-Check database size and indexes:
 ```bash
 psql $DATABASE_URL -c "\dt+"
 psql $DATABASE_URL -c "\di+"
 ```
 
 ### Scanning Performance
-Monitor scan throughput via logs:
 ```bash
 docker logs pixelprobe | grep "Scan completed"
 ```
@@ -67,25 +60,15 @@ docker logs pixelprobe | grep "Scan completed"
 ## Recommendations for Large Datasets
 
 ### For 1M+ Files
-- Increase `MAX_SCAN_WORKERS` to 8-16 (based on CPU cores)
-- Set `RESET_BATCH_SIZE` to 1000-2000
+- Increase `CELERY_CONCURRENCY` to 8-16 (based on CPU cores)
 - Ensure PostgreSQL is tuned for high concurrent workloads
+- Use `time_budget_minutes` on file-changes schedules so rolling integrity checks stay within a maintenance window
 
 ### For Memory-Constrained Environments
-- Reduce `MAX_SCAN_WORKERS` to 2-4
-- Set `RESET_BATCH_SIZE` to 200-300
-- Set `BATCH_COMMIT_SIZE` to 25-30
+- Reduce `CELERY_CONCURRENCY` to 2
+- Reduce `MAX_WORKERS` to 4
+- Lower `REDIS_MAX_MEMORY` to 1gb
 
 ### For High-Performance Storage
-- Increase `MAX_SCAN_WORKERS` based on storage IOPS
-- Consider using tmpfs for temporary files during scanning
-- Ensure database is on fast storage (SSD)
-
-## Database Migration
-
-If you're upgrading from a previous version, run the index creation script:
-```bash
-python create_indexes.py
-```
-
-This will add performance indexes without affecting existing data.
+- Increase `CELERY_CONCURRENCY` based on storage IOPS
+- Ensure the database is on fast storage (SSD)

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -26,6 +26,7 @@ PixelProbe/
 │   │
 │   ├── api/                  # Route blueprints
 │   │   ├── admin_routes.py       # Configurations, schedules, exclusions, ignored patterns
+│   │   ├── auth_decorator.py     # Authentication decorator
 │   │   ├── auth_routes.py        # Login, logout, users, tokens
 │   │   ├── export_routes.py      # CSV/data export, file viewer
 │   │   ├── healthcheck_routes.py # Healthcheck integration
@@ -33,6 +34,7 @@ PixelProbe/
 │   │   ├── maintenance_routes.py # Cleanup, file-changes, vacuum
 │   │   ├── notification_routes.py # Notification providers and rules
 │   │   ├── reports_routes.py     # Scan reports, PDF generation
+│   │   ├── scan_launch.py        # Shared scan-launch helper
 │   │   ├── scan_routes.py        # Core scan operations
 │   │   ├── scan_routes_parallel.py # Parallel scan endpoint
 │   │   └── stats_routes.py       # Statistics, trends, system info
@@ -43,7 +45,9 @@ PixelProbe/
 │   │   ├── healthcheck_service.py
 │   │   ├── maintenance_service.py
 │   │   ├── notification_service.py
+│   │   ├── scan_engine.py        # Chunk building, scan finalization
 │   │   ├── scan_executor.py
+│   │   ├── scan_reporting.py     # Scan reports, batch file inserts
 │   │   ├── scan_service.py
 │   │   └── stats_service.py
 │   │
@@ -56,6 +60,8 @@ PixelProbe/
 │   │   ├── celery_utils.py       # check_celery_available, safe_check_task_state
 │   │   ├── decorators.py
 │   │   ├── helpers.py            # ProgressTracker, batch_process, state utilities
+│   │   ├── integrity.py          # File change classification (bitrot detection)
+│   │   ├── paths.py              # Path prefix/containment helpers
 │   │   ├── rate_limiting.py      # rate_limit, exempt_from_rate_limit
 │   │   ├── log_context.py          # ContextVar-based scan/task log tagging
 │   │   ├── log_handler.py          # Database log handler (background batch writer)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,6 @@
 
 ### Development
 - **[Developer Guide](developer/README.md)** - Setup and contribution guidelines
-- **[API Consolidation Plan](development/API_CONSOLIDATION_PLAN.md)** - API improvement roadmap
-- **[P0/P1 Implementation Status](development/P0_P1_IMPLEMENTATION_STATUS.md)** - Audit task completion status (v2.2.50)
 
 ### API Documentation
 - **[API Reference](api/README.md)** - Complete API endpoint documentation
@@ -49,17 +47,4 @@
 
 ## Documentation Standards
 
-When contributing documentation:
-- Use clear, concise language
-- Include practical examples
-- Keep technical accuracy
-- Update the relevant index files
-- Test all code examples
-- Maintain consistent formatting
-
-## Finding Information
-
-- **Installation**: See [Docker Setup](DOCKER_SETUP.md)
-- **API Usage**: Check [API Reference](api/README.md)
-- **Contributing**: Read [Developer Guide](developer/README.md)
-- **Architecture**: Study [System Architecture](SYSTEM_ARCHITECTURE.md)
+When contributing documentation, test all code examples and update this index if you add or move files.

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -10,7 +10,7 @@
 
 ## Overview
 
-PixelProbe is a distributed media corruption detection system built on a microservices architecture using Docker containers. The system uses Celery for distributed task processing, Redis for message queuing, and PostgreSQL for persistent storage.
+PixelProbe is a distributed media corruption detection system that runs as a set of Docker containers. It uses Celery for distributed task processing, Redis for message queuing, and PostgreSQL for persistent storage.
 
 ## Container Architecture
 

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -75,7 +75,7 @@ PixelProbe is a distributed media corruption detection system built on a microse
   - Python PIL for additional image processing
 
 #### 3. Redis Container
-- **Image**: `redis:7-alpine`
+- **Image**: `valkey/valkey:9-alpine`
 - **Purpose**: Message broker and result backend
 - **Responsibilities**:
   - Queue task messages
@@ -85,7 +85,7 @@ PixelProbe is a distributed media corruption detection system built on a microse
 - **Persistence**: Optional volume mount for data persistence
 
 #### 4. PostgreSQL Container
-- **Image**: `postgres:15-alpine`
+- **Image**: `postgres:18-alpine`
 - **Purpose**: Primary data storage
 - **Responsibilities**:
   - Store scan results
@@ -393,13 +393,13 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:15-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_DB: pixelprobe
       POSTGRES_USER: pixelprobe
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U pixelprobe"]
       interval: 10s
@@ -407,10 +407,10 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
-    command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
+    image: valkey/valkey:9-alpine
+    command: valkey-server --maxmemory 256mb --maxmemory-policy allkeys-lru
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -22,7 +22,7 @@ PixelProbe is a distributed media corruption detection system built on a microse
 │  │                 │       │                 │      │                 │   │
 │  │   Web App       │◄─────►│     Redis       │◄────►│  Celery Worker  │   │
 │  │   (Flask)       │       │   (Message      │      │     Pool        │   │
-│  │   Port: 5000    │       │    Broker)      │      │   (8 workers)   │   │
+│  │   Port: 5000    │       │    Broker)      │      │   (4 workers)   │   │
 │  │                 │       │   Port: 6379    │      │                 │   │
 │  └────────┬────────┘       └─────────────────┘      └────────┬────────┘   │
 │           │                                                   │             │
@@ -56,7 +56,7 @@ PixelProbe is a distributed media corruption detection system built on a microse
 - **Key Processes**:
   - Gunicorn WSGI server
   - Flask application
-  - APScheduler for scheduled tasks
+  - (Scheduler disabled: `SCHEDULER_ENABLED=false` keeps the web container out of the scheduler lock)
 
 #### 2. Celery Worker Container (`celery-worker`)
 - **Image**: `ttlequals0/pixelprobe:latest` (same image, different entry point)
@@ -66,9 +66,11 @@ PixelProbe is a distributed media corruption detection system built on a microse
   - Process file discovery operations
   - Handle cleanup operations
   - Report progress to Redis
+  - Run APScheduler for scheduled tasks (leader election via a Redis lock: `SET NX` with a per-process uuid value, 60s TTL, refreshed by a heartbeat that atomically compares the value before extending the expiry)
 - **Configuration**:
-  - Default: 8 concurrent workers
-  - Configurable via `CELERY_WORKERS` environment variable
+  - Started via `python celery_worker.py`, which consumes the `pixelprobe` queue with `--max-tasks-per-child 1000`, a 2GB `--max-memory-per-child` limit, and `--without-gossip/--without-mingle/--without-heartbeat`
+  - Default: 4 concurrent workers
+  - Configurable via `CELERY_CONCURRENCY` environment variable
 - **Tools Available**:
   - FFmpeg for video/audio analysis
   - ImageMagick for image analysis
@@ -94,7 +96,7 @@ PixelProbe is a distributed media corruption detection system built on a microse
   - Store user configurations
   - Manage scan state
 - **Features**:
-  - Connection pooling (20 base, 40 max)
+  - Connection pooling (5 base, 10 overflow, 15 max per process)
   - Automatic reconnection
   - Transaction support
 
@@ -121,6 +123,10 @@ All tasks use a single queue for simplicity and load balancing.
 - `process_chunk_task`: Process FCP path-range chunks (last chunk finalizes the scan)
 - `scan_media_task`: Single-file scans + compatibility shim for queued directory scans
 - `scan_files_task`: Selected-file batch rescans
+- `check_file_exists_task`: File existence checks for cleanup
+- `calculate_file_hash_task`: Hash recalculation for file-changes / integrity checks
+- `run_retention_cleanup`: Data retention cleanup
+- `reload_schedules_task`: Signal schedule reload after create/update/delete
 - `health_check_task`: System health monitoring
 
 ### Parallel Scanning Workflow
@@ -160,15 +166,14 @@ All tasks use a single queue for simplicity and load balancing.
 ### Task Distribution Strategy
 
 1. **Chunk-Based Distribution**:
-   - Files are divided into chunks of configurable size (default: 100 files)
+   - Files are divided into path-range chunks; chunk size adapts to scan size (<=100 files: single chunk, <=1,000: 100/chunk, <=10,000: 500/chunk, larger: 1,000/chunk)
    - Each chunk becomes an independent task
    - Workers pull chunks from queue as they become available
 
 2. **Worker Pool Management**:
    - Workers are stateless and interchangeable
-   - Automatic retry on failure (3 attempts)
-   - Exponential backoff: 30s, 60s, 120s
-   - Dead letter queue for failed tasks
+   - Automatic retry on failure (3 attempts, fixed 60s delay)
+   - `task_acks_late` + `task_reject_on_worker_lost` redeliver tasks lost to a worker crash
 
 3. **Load Balancing**:
    - Redis automatically distributes tasks to available workers
@@ -217,9 +222,9 @@ Media File → FFmpeg/ImageMagick → Analysis Result → PostgreSQL
 - **Protocol**: PostgreSQL wire protocol
 - **Purpose**: CRUD operations on data
 - **Connection Pool**:
-  - Base: 20 connections
-  - Max overflow: 20 connections
-  - Total max: 40 connections
+  - Base: 5 connections (`DB_POOL_SIZE`)
+  - Max overflow: 10 connections (`DB_MAX_OVERFLOW`)
+  - Total max: 15 connections per process
   - Recycle time: 3600 seconds
 
 ### 3. Celery Workers ↔ Redis
@@ -262,7 +267,7 @@ REDIS_PORT: 6379
 # Celery
 CELERY_BROKER_URL: redis://redis:6379/0
 CELERY_RESULT_BACKEND: redis://redis:6379/0
-CELERY_WORKERS: 8
+CELERY_CONCURRENCY: 4
 
 # Application
 SECRET_KEY: <secure-key>
@@ -278,14 +283,14 @@ BATCH_SIZE: 100
 ```yaml
 celery-worker-2:
   image: ttlequals0/pixelprobe:latest
-  command: celery -A celery_app worker
+  command: python celery_worker.py
   scale: 4  # Creates 4 instances
 ```
 
 2. **Increase Worker Concurrency**:
 ```yaml
 environment:
-  CELERY_WORKERS: 16  # Double the workers
+  CELERY_CONCURRENCY: 8  # Double the workers
 ```
 
 ### Vertical Scaling
@@ -306,9 +311,8 @@ deploy:
 
 ### Performance Tuning
 
-1. **Chunk Size Optimization**:
-   - Smaller chunks (50): Better for many small files
-   - Larger chunks (200): Better for fewer large files
+1. **Chunk Sizing**:
+   - Chunk size is chosen automatically based on scan size (see Task Distribution Strategy); it is not configurable
 
 2. **Worker Specialization**:
    - Dedicate workers for specific file types
@@ -324,7 +328,7 @@ deploy:
 ### Health Check Endpoints
 - `/health`: Web application health
 - `/api/scan-status`: Current scan status
-- `/api/scan/parallel-v2/workers`: Worker status
+- `/api/scan-parallel/workers`: Worker status
 
 ### Metrics to Monitor
 1. **Queue Depth**: Tasks waiting in Redis
@@ -347,14 +351,13 @@ healthcheck:
 ### Automatic Recovery Mechanisms
 
 1. **Stuck Scan Detection**:
-   - Timeout: 5 minutes for adding phase
-   - Timeout: 10 minutes for discovery phase
-   - Automatic cleanup and restart
+   - Sweep runs every 5 minutes
+   - Scans with no update for 30 minutes are marked crashed
+   - Backstop also finalizes scans whose last chunk died before finalization
 
 2. **Worker Crash Recovery**:
-   - Supervisor monitors worker processes
-   - Automatic restart on crash
-   - Task reassignment to healthy workers
+   - Worker exits non-zero on unrecoverable errors; the container restart policy brings it back
+   - `task_acks_late` redelivers in-flight tasks to healthy workers
 
 3. **Database Connection Recovery**:
    - Automatic reconnection
@@ -374,10 +377,9 @@ healthcheck:
    - API authentication required
 
 2. **Resource Limits**:
-   - Memory limits per container
+   - Memory limits per container (plus a 2GB `--max-memory-per-child` cap on worker children)
    - CPU limits to prevent DoS
-   - File size limits (5GB max)
-   - Scan timeout (5 minutes per file)
+   - Per-tool timeouts sized dynamically from file size and duration (files over 5GB additionally get stage-3 multi-point sampling)
 
 3. **Input Validation**:
    - Path traversal prevention
@@ -435,13 +437,13 @@ services:
 
   celery-worker:
     image: ttlequals0/pixelprobe:latest
-    command: celery -A celery_app worker --loglevel=info --concurrency=8
+    command: python celery_worker.py
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       REDIS_HOST: redis
       CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_WORKERS: 8
+      CELERY_CONCURRENCY: 4
     volumes:
       - /media:/media:ro
     depends_on:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -30,13 +30,16 @@ docker-compose ps
 docker-compose logs --tail=50
 
 # Check specific service
-docker-compose logs pixelprobe-app --tail=100
-docker-compose logs pixelprobe-celery-worker --tail=100
-docker-compose logs pixelprobe-postgres --tail=50
-docker-compose logs pixelprobe-redis --tail=50
+docker-compose logs pixelprobe --tail=100
+docker-compose logs celery-worker --tail=100
+docker-compose logs postgres --tail=50
+docker-compose logs redis --tail=50
 
-# Check health status
-curl http://localhost:5000/health
+# Check health status (unauthenticated liveness probe)
+curl http://localhost:5000/healthz
+
+# Authenticated health check
+curl http://localhost:5000/health -H "Authorization: Bearer your-token-here"
 ```
 
 ### Manual Installation
@@ -426,7 +429,7 @@ curl http://localhost:5000/api/scan-status
 
 2. **Check database connection:**
 ```bash
-docker-compose logs pixelprobe-app | grep -i database
+docker-compose logs pixelprobe | grep -i database
 ```
 
 3. **Verify write permissions:**
@@ -550,7 +553,7 @@ LIMIT 10;
 
 1. **Create indexes** (should be automatic):
 ```bash
-docker exec pixelprobe-app python tools/create_indexes.py
+docker exec pixelprobe-app python scripts/create_indexes.py
 ```
 
 2. **Vacuum and analyze:**
@@ -578,14 +581,23 @@ docker exec pixelprobe-postgres psql -U pixelprobe -c \
   "SELECT username, is_admin FROM users WHERE is_admin = true;"
 ```
 
-2. **Reset admin account** (if locked out):
+2. **Reset admin password** (if locked out):
+
+First-run setup only works before any user exists. If a user already exists,
+generate a bcrypt hash and update the users table directly:
 ```bash
-docker exec pixelprobe-app python tools/reset_admin.py
+# Generate a bcrypt hash for the new password
+docker exec pixelprobe-app python -c \
+  "import bcrypt; print(bcrypt.hashpw(b'new-password', bcrypt.gensalt()).decode())"
+
+# Set it on the locked-out account
+docker exec pixelprobe-postgres psql -U pixelprobe -d pixelprobe -c \
+  "UPDATE users SET password_hash = 'paste-hash-here' WHERE username = 'admin';"
 ```
 
 3. **Check SECRET_KEY is set:**
 ```bash
-docker-compose logs pixelprobe-app | grep SECRET_KEY
+docker-compose logs pixelprobe | grep SECRET_KEY
 ```
 
 ### API Token Not Working
@@ -614,7 +626,7 @@ curl http://localhost:5000/api/stats \
 
 **Solution:**
 
-Session timeout is 30 days by default. If experiencing issues:
+Sessions last 24 hours, with an additional 30-minute inactivity timeout. Being logged out after 30 minutes of inactivity is expected behavior. If sessions expire faster than that:
 
 1. **Check browser cookies enabled**
 2. **Check SECRET_KEY hasn't changed** (invalidates sessions)
@@ -841,7 +853,7 @@ DATABASE_ECHO=true
 
 View queries:
 ```bash
-docker-compose logs pixelprobe-app | grep SELECT
+docker-compose logs pixelprobe | grep SELECT
 ```
 
 ## Log Locations
@@ -913,7 +925,9 @@ docker --version
 docker-compose --version
 
 # PixelProbe version
-docker exec pixelprobe-app cat version.py
+curl http://localhost:5000/healthz
+# or
+docker exec pixelprobe-app cat pixelprobe/version.py
 
 # Container status
 docker-compose ps
@@ -921,8 +935,8 @@ docker-compose ps
 # Recent logs (last 100 lines)
 docker-compose logs --tail=100 > logs.txt
 
-# Health check
-curl http://localhost:5000/health
+# Health check (unauthenticated liveness probe)
+curl http://localhost:5000/healthz
 
 # Database status
 docker exec pixelprobe-postgres psql -U pixelprobe -c \

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,7 +1,5 @@
 # PixelProbe Troubleshooting Guide
 
-This guide helps you diagnose and fix common issues with PixelProbe.
-
 ## Table of Contents
 
 - [Quick Diagnostics](#quick-diagnostics)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -194,7 +194,7 @@ docker network inspect pixelprobe-network
 docker-compose logs postgres
 
 # Manual
-sudo tail -f /var/log/postgresql/postgresql-15-main.log
+sudo tail -f /var/log/postgresql/postgresql-18-main.log
 ```
 
 ### Database Table Missing
@@ -875,7 +875,7 @@ journalctl -u pixelprobe -f
 
 **PostgreSQL logs:**
 ```bash
-sudo tail -f /var/log/postgresql/postgresql-15-main.log
+sudo tail -f /var/log/postgresql/postgresql-18-main.log
 ```
 
 **Redis logs:**

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-PixelProbe provides a RESTful API for managing media file corruption detection. The API is built with Flask and follows REST conventions.
+PixelProbe exposes its media corruption detection through a REST API built with Flask.
 
 ## Base URL
 
@@ -464,7 +464,7 @@ Also includes per-scan-type duration statistics.
 GET /api/system-info
 ```
 
-Get comprehensive system information including database statistics (total/completed/pending/corrupted/healthy/warning file counts) and per-path file counts for the monitored paths.
+Get system information including database statistics (total/completed/pending/corrupted/healthy/warning file counts) and per-path file counts for the monitored paths.
 
 ### Admin Endpoints
 
@@ -816,12 +816,10 @@ Future versions will include WebSocket support for real-time updates:
 
 ## Best Practices
 
-1. **Check scan status** before starting a new scan to avoid conflicts
-2. **Use pagination** when retrieving large result sets
-3. **Implement exponential backoff** when rate limited
-4. **Validate file paths** before submitting scan requests
-5. **Monitor cleanup progress** via `/api/cleanup-status` after starting a cleanup
-6. **Monitor rate limit headers** to avoid hitting limits
+- Check `/api/scan-status` before starting a new scan; the API returns 409 if one is already running.
+- Use pagination for large result sets rather than `per_page=-1`.
+- Watch the rate limit headers and back off with exponential delay on 429 responses.
+- After starting a cleanup, poll `GET /api/cleanup-status` for progress.
 
 ## Security Considerations
 
@@ -835,17 +833,10 @@ Future versions will include WebSocket support for real-time updates:
 
 ### Common Errors
 
-**409 Conflict - "Another scan is already in progress"**
-- Solution: Wait for current scan to complete or cancel it
-
-**400 Bad Request - "Invalid file path"**
-- Solution: Ensure file path is within allowed directories
-
-**429 Too Many Requests**
-- Solution: Implement rate limiting in your client
-
-**500 Internal Server Error**
-- Solution: Check server logs for details
+- **409 "Another scan is already in progress"**: wait for the current scan or cancel it via `/api/cancel-scan`
+- **400 "Invalid file path"**: the path must be inside a configured scan directory
+- **429 Too Many Requests**: back off and retry; see the rate limit headers
+- **500 Internal Server Error**: check the server logs
 
 ### Debug Headers
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -58,11 +58,12 @@ response = requests.get('http://localhost:5000/api/scan-status', headers=headers
 
 ## Rate Limiting
 
-The API implements rate limiting to prevent abuse:
-- **Default limits**: 200 requests per day, 50 per hour
+The API implements rate limiting on specific endpoints to prevent abuse:
+- **No default/global limits**: only individually decorated endpoints are rate limited
 - **Scan operations**: 2-5 requests per minute
 - **Admin operations**: 10 requests per minute
 - **Maintenance operations**: 5 requests per minute
+- **Exemptions**: requests from localhost and private/Docker networks (127.0.0.1, 10.x, 172.x, 192.168.x) are exempt from rate limiting
 
 Rate limit headers are included in responses:
 - `X-RateLimit-Limit`: Maximum requests allowed
@@ -100,12 +101,27 @@ Common status codes:
 
 ### System Endpoints
 
-#### Health Check
+#### Liveness Probe (Unauthenticated)
+```http
+GET /healthz
+```
+
+Unauthenticated liveness probe intended for container healthchecks and load balancers.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "version": "<current_version>"
+}
+```
+
+#### Health Check (Authenticated)
 ```http
 GET /health
 ```
 
-Check if the service is running.
+Check if the service is running. Requires authentication.
 
 **Response:**
 ```json
@@ -143,9 +159,11 @@ Get paginated scan results with optional filters.
 
 **Query Parameters:**
 - `page` (integer): Page number (default: 1)
-- `per_page` (integer): Results per page (default: 100, max: 500)
+- `per_page` (integer): Results per page (default: 100, use -1 for all)
 - `scan_status` (string): Filter by status: `all`, `pending`, `scanning`, `completed`, `error`
 - `is_corrupted` (string): Filter by corruption: `all`, `true`, `false`
+- `search` (string): Case-insensitive substring match on file path
+- `path` (string): Restrict results to one configured scan path (must exactly match a configured path)
 
 **Response:**
 ```json
@@ -210,12 +228,12 @@ Scan a single file for corruption. Rate limited to 5 requests per minute.
 }
 ```
 
-#### Scan All Files
+#### Start Scan
 ```http
-POST /api/scan-all
+POST /api/scan
 ```
 
-Start scanning all configured directories. Rate limited to 2 requests per minute.
+Start scanning all configured directories (or a supplied list). Distributes work across all available Celery workers in chunks. Rate limited to 2 requests per minute.
 
 **Request Body:**
 ```json
@@ -225,102 +243,78 @@ Start scanning all configured directories. Rate limited to 2 requests per minute
 }
 ```
 
+Both fields are optional; if `directories` is omitted, the configured scan paths are used.
+
 **Response:**
 ```json
 {
-  "message": "Scan started",
-  "directories": ["/media/photos", "/media/videos"],
-  "force_rescan": false
+  "status": "queued",
+  "scan_id": "uuid-string",
+  "task_id": "celery-task-id",
+  "message": "Scan queued successfully using Celery task queue",
+  "celery_enabled": true
 }
 ```
 
-#### Parallel Scan
+#### Parallel Scan (Deprecated)
 ```http
 POST /api/scan-parallel
 ```
 
-Start a parallel scan with multiple workers. Rate limited to 2 requests per minute.
+Deprecated alias of `/api/scan`; both run the same chunk-distributed engine. Kept for API compatibility and will be removed in a future major release. Rate limited to 2 requests per minute.
 
 **Request Body:**
 ```json
 {
-  "force_rescan": false,
-  "num_workers": 4,
-  "directories": ["/media/photos"]
+  "directories": ["/media/photos"],
+  "force_rescan": false
 }
 ```
 
-#### Enhanced Parallel Scan V2
+`directories` is required; `force_rescan` is optional. The response matches `/api/scan` plus legacy fields (`status: "launched"`, `scan_type`, `force_rescan`, `directories`).
+
+#### Get Parallel Scan Status
 ```http
-POST /api/scan/parallel-v2
+GET /api/scan-parallel/status/<scan_id>
 ```
 
-Start an enhanced parallel scan that distributes work across all available Celery workers.
-
-**Request Body:**
-```json
-{
-  "directories": ["/media/photos", "/media/videos"],
-  "force_rescan": false,
-  "chunk_size": 100
-}
-```
+Get detailed status of a scan including chunk progress.
 
 **Response:**
 ```json
 {
   "scan_id": "uuid-string",
-  "message": "Enhanced parallel scan started",
-  "total_workers": 8,
-  "chunks_created": 42
-}
-```
-
-#### Get Parallel Scan V2 Status
-```http
-GET /api/scan/parallel-v2/status/<scan_id>
-```
-
-Get detailed status of an enhanced parallel scan including chunk progress.
-
-**Response:**
-```json
-{
-  "scan_id": "uuid-string",
-  "status": "running",
-  "total_chunks": 42,
-  "completed_chunks": 15,
-  "progress_percentage": 35.7,
-  "estimated_time_remaining": "5 minutes",
-  "worker_status": {
-    "active": 8,
-    "idle": 0
-  }
+  "phase": "scanning",
+  "is_active": true,
+  "progress_percent": 35.71,
+  "chunks": {
+    "total": 42,
+    "complete": 15,
+    "remaining": 27
+  },
+  "active_workers": 8,
+  "active_tasks": [
+    {
+      "worker": "celery@worker-1",
+      "task_id": "task-uuid",
+      "name": "pixelprobe.tasks_parallel.scan_chunk",
+      "args": [],
+      "kwargs": {"scan_id": "uuid-string"}
+    }
+  ],
+  "files_processed": 1500,
+  "estimated_total": 4200,
+  "start_time": "2025-01-20T12:00:00Z",
+  "message": "Processing 15/42 chunks"
 }
 ```
 
 #### Get Worker Status
 ```http
-GET /api/scan/parallel-v2/workers
+GET /api/scan-parallel/workers
 ```
 
-Get current status and utilization of all Celery workers.
-
-**Response:**
-```json
-{
-  "total_workers": 8,
-  "active_workers": 6,
-  "idle_workers": 2,
-  "worker_details": [
-    {
-      "worker_id": "worker-1",
-      "status": "busy",
-      "current_task": "processing chunk 5"
-    }
-  ]
-}
-```
+Get current status and utilization of all Celery workers. Returns `{"status": "offline", "message": "No Celery workers available"}` when no workers are up; otherwise per-worker details including pool size and active tasks.
 
 #### Get Scan Status
 ```http
@@ -363,9 +357,9 @@ Cancel the currently running scan.
 
 ### Statistics Endpoints
 
-#### Summary Statistics
+#### Statistics
 ```http
-GET /api/stats/summary
+GET /api/stats
 ```
 
 Get overall statistics about scanned files.
@@ -374,65 +368,103 @@ Get overall statistics about scanned files.
 ```json
 {
   "total_files": 1000,
-  "scanned_files": 950,
+  "completed_files": 950,
+  "pending_files": 50,
+  "scanning_files": 0,
+  "error_files": 5,
   "corrupted_files": 10,
   "healthy_files": 940,
-  "pending_files": 50,
-  "error_files": 5,
-  "total_size": 10737418240,
-  "corrupted_size": 52428800,
-  "last_scan_date": "2025-01-20T12:00:00Z",
-  "corruption_rate": 1.05
+  "marked_as_good": 3,
+  "warning_files": 7,
+  "integrity": {
+    "total_files": 1000,
+    "checked_files": 800,
+    "checked_percent": 80.0,
+    "checked_last_30_days": 500,
+    "never_checked": 200,
+    "oldest_check_date": "2025-01-01T00:00:00Z",
+    "bitrot_suspected": 2
+  }
 }
 ```
 
-#### Corruption by File Type
+#### Scan Trends
 ```http
-GET /api/stats/corruption-by-type
+GET /api/stats/trends?days=30
 ```
 
-Get corruption statistics grouped by file type.
+Get scan counter metrics over time.
+
+**Query Parameters:**
+- `days` (integer): Number of days to look back (default: 30, max: 365)
 
 **Response:**
 ```json
-[
-  {
-    "file_type": "image/jpeg",
-    "total_files": 500,
-    "corrupted_files": 5,
-    "corruption_rate": 1.0
+{
+  "period_days": 30,
+  "start_date": "2024-12-21T12:00:00Z",
+  "summary": {
+    "total_scans": 12,
+    "total_files_scanned": 5000,
+    "total_corrupted": 8,
+    "total_warnings": 15
   },
-  {
-    "file_type": "video/mp4",
-    "total_files": 200,
-    "corrupted_files": 3,
-    "corruption_rate": 1.5
-  }
-]
+  "daily_trends": [
+    {
+      "date": "2025-01-20",
+      "scan_count": 2,
+      "scan_types_count": 1,
+      "files_scanned": 100,
+      "files_corrupted": 2,
+      "files_with_warnings": 1,
+      "avg_duration_seconds": 120.5
+    }
+  ]
+}
 ```
 
-#### Scan History
+#### Scan Duration Histogram
 ```http
-GET /api/stats/scan-history?days=30
+GET /api/stats/duration-histogram?days=30&buckets=10
 ```
 
-Get scan history for the specified number of days.
+Get a histogram of scan durations.
+
+**Query Parameters:**
+- `days` (integer): Number of days to look back (default: 30, max: 365)
+- `buckets` (integer): Number of histogram buckets (default: 10, min: 2, max: 50)
 
 **Response:**
 ```json
-[
-  {
-    "date": "2025-01-20",
-    "files_scanned": 100,
-    "corrupted_found": 2
-  },
-  {
-    "date": "2025-01-19",
-    "files_scanned": 150,
-    "corrupted_found": 1
+{
+  "period_days": 30,
+  "start_date": "2024-12-21T12:00:00Z",
+  "histogram": [
+    {
+      "range_start": 0.0,
+      "range_end": 60.0,
+      "count": 5,
+      "percentage": 41.67
+    }
+  ],
+  "summary": {
+    "total_scans": 12,
+    "min_duration": 10.2,
+    "max_duration": 600.0,
+    "avg_duration": 180.4,
+    "median_duration": 150.0
   }
-]
+}
 ```
+
+Also includes per-scan-type duration statistics.
+
+#### System Information
+```http
+GET /api/system-info
+```
+
+Get comprehensive system information including database statistics (total/completed/pending/corrupted/healthy/warning file counts) and per-path file counts for the monitored paths.
 
 ### Admin Endpoints
 
@@ -589,7 +621,7 @@ After fixing underlying issues (e.g., database problems), use the `/api/reset-fi
 
 ### Export Endpoints
 
-#### Export Scan Results (Enhanced)
+#### Export Scan Results
 ```http
 GET /api/export?format=csv
 POST /api/export
@@ -599,70 +631,48 @@ Export scan results in multiple formats (CSV, JSON, or PDF).
 
 **Query Parameters (GET):**
 - `format` (string): Output format - `csv`, `json`, or `pdf` (default: csv)
-- `scan_status` (string): Filter by status - `all`, `pending`, `completed`, `error`
-- `is_corrupted` (string): Filter by corruption - `all`, `true`, `false`
-- `start_date` (string): Start date in ISO format
-- `end_date` (string): End date in ISO format
+- `filter` (string): Filter type - `all`, `corrupted`, `healthy`, `warning` (default: all)
+- `search` (string): Search term to filter by file path
 
 **Request Body (POST):**
 ```json
 {
   "format": "pdf",
-  "filters": {
-    "scan_status": "completed",
-    "is_corrupted": "true",
-    "start_date": "2025-01-01",
-    "end_date": "2025-01-31"
-  }
+  "filter": "corrupted",
+  "search": "vacation",
+  "file_ids": [1, 2, 3]
 }
 ```
+
+If `file_ids` is provided, only those specific results are exported and `filter`/`search` are ignored.
 
 **Response:** File download in requested format
 
-#### Export to CSV (Legacy)
-```http
-POST /api/export/csv
-```
-
-Export scan results to CSV format (legacy endpoint, use `/api/export` instead).
-
-**Request Body:**
-```json
-{
-  "filters": {
-    "scan_status": "completed",
-    "is_corrupted": "true",
-    "start_date": "2025-01-01",
-    "end_date": "2025-01-31"
-  }
-}
-```
-
-**Response:** CSV file download
-
 ### Maintenance Endpoints
 
-#### Cleanup Missing Files
+#### Cleanup Orphaned Entries
 ```http
-POST /api/cleanup
+POST /api/cleanup-orphaned
 ```
 
-Remove database entries for files that no longer exist. Rate limited to 10 requests per minute.
+Start a background cleanup of database entries for files that no longer exist on disk. Returns `409 Conflict` if a cleanup is already in progress. Progress can be monitored via `GET /api/cleanup-status`.
 
-**Request Body:**
+**Request Body (optional):**
 ```json
 {
-  "dry_run": true,
-  "directories": ["/media/photos"]
+  "file_paths": ["/media/photos/missing.jpg"]
 }
 ```
+
+If `file_paths` is omitted, all files are checked.
 
 **Response:**
 ```json
 {
-  "missing_files": 10,
-  "cleaned_files": 0,
-  "dry_run": true
+  "status": "started",
+  "message": "Cleanup operation started for all files",
+  "cleanup_id": 12,
+  "file_count": null
 }
 ```
 
@@ -744,7 +754,7 @@ response = requests.get(f"{BASE_URL}/api/scan-results", params={
 results = response.json()
 
 # Start a scan
-response = requests.post(f"{BASE_URL}/api/scan-all", json={
+response = requests.post(f"{BASE_URL}/api/scan", json={
     "force_rescan": False,
     "directories": ["/media/photos"]
 })
@@ -775,7 +785,7 @@ async function getScanResults() {
 
 // Start a scan
 async function startScan() {
-  const response = await axios.post(`${BASE_URL}/api/scan-all`, {
+  const response = await axios.post(`${BASE_URL}/api/scan`, {
     force_rescan: false,
     directories: ['/media/photos']
   });
@@ -789,7 +799,7 @@ async function startScan() {
 curl -X GET "http://localhost:5000/api/scan-results?is_corrupted=true"
 
 # Start a scan
-curl -X POST "http://localhost:5000/api/scan-all" \
+curl -X POST "http://localhost:5000/api/scan" \
   -H "Content-Type: application/json" \
   -d '{"force_rescan": false, "directories": ["/media/photos"]}'
 
@@ -810,7 +820,7 @@ Future versions will include WebSocket support for real-time updates:
 2. **Use pagination** when retrieving large result sets
 3. **Implement exponential backoff** when rate limited
 4. **Validate file paths** before submitting scan requests
-5. **Use dry_run** for cleanup operations to preview changes
+5. **Monitor cleanup progress** via `/api/cleanup-status` after starting a cleanup
 6. **Monitor rate limit headers** to avoid hitting limits
 
 ## Security Considerations

--- a/docs/api/SCAN_TYPES_DOCUMENTATION.md
+++ b/docs/api/SCAN_TYPES_DOCUMENTATION.md
@@ -64,7 +64,7 @@ POST /api/scan
 POST /api/scan-parallel
 {
   "directories": ["/media"],
-  "num_workers": 8
+  "force_rescan": false
 }
 ```
 

--- a/docs/api/SCAN_TYPES_DOCUMENTATION.md
+++ b/docs/api/SCAN_TYPES_DOCUMENTATION.md
@@ -1,7 +1,7 @@
 # PixelProbe Scan Types Documentation
 
 ## Overview
-PixelProbe offers multiple scan types to handle different use cases for media file corruption detection. Each scan type is optimized for specific scenarios and workflows.
+PixelProbe has several scan types for different corruption-detection workflows.
 
 ## Scan Types
 
@@ -235,11 +235,9 @@ All multi-file scan types follow a three-phase approach:
 - **Pending scan**: Depends on pending count
 
 ### Optimization Tips
-1. Use parallel scans for initial setup
-2. Schedule file_changes scans regularly
-3. Run orphan cleanup weekly
-4. Use force_rescan sparingly
-5. Increase workers for parallel scans on powerful systems
+- Use force_rescan sparingly; it re-checks files that already have results.
+- On powerful systems, increase the worker count for parallel scans.
+- For scheduling cadence, see Best Practices below.
 
 ## Scan Status Values
 
@@ -314,27 +312,8 @@ Files can have the following scan statuses:
 
 ## Best Practices
 
-1. **Initial Setup**
-   - Run full scan on all media directories
-   - Use parallel scan for large libraries
-   - Review corrupted files immediately
-
-2. **Regular Maintenance**
-   - Schedule daily file_changes scans
-   - Weekly orphan cleanup
-   - Monthly full scan for critical data
-
-3. **Performance**
-   - Use parallel scans during off-hours
-   - Limit worker count during business hours
-   - Monitor system resources during scans
-
-4. **Error Handling**
-   - Check scan logs for errors
-   - Re-scan error files individually
-   - Mark false positives as good
-
-5. **Database Maintenance**
-   - Regular orphan cleanup
-   - Backup database before major scans
-   - Monitor database size growth
+- Initial setup: run a full scan on all media directories (parallel for large libraries).
+- Ongoing: schedule daily file_changes scans, weekly orphan cleanup, and a monthly full scan for critical data.
+- Run heavy scans during off-hours; limit worker count during business hours.
+- Re-scan error files individually and mark false positives as good.
+- Back up the database before major scans.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -126,7 +126,7 @@ docker-compose up -d
    - Query optimization
    - Transaction management
 
-5. **Core Scanner** (`media_checker.py`)
+5. **Core Scanner** (`pixelprobe/media_checker.py`)
    - File discovery
    - Corruption detection
    - Multi-tool validation
@@ -136,16 +136,16 @@ docker-compose up -d
 ```
 PixelProbe/
 ├── app.py                    # Application entry point
-├── media_checker.py          # Core scanning engine
-├── models.py                 # SQLAlchemy models
-├── scheduler.py              # Scheduled scan management
-├── version.py                # Version information
 ├── requirements.txt          # Python dependencies
 ├── Dockerfile               # Docker configuration
 ├── docker-compose.yml       # Docker Compose setup
 │
 ├── pixelprobe/              # Main application package
 │   ├── __init__.py
+│   ├── media_checker.py     # Core scanning engine
+│   ├── models.py            # SQLAlchemy models
+│   ├── scheduler.py         # Scheduled scan management
+│   ├── version.py           # Version information
 │   ├── api/                 # API endpoints
 │   │   ├── scan_routes.py   # Scanning endpoints
 │   │   ├── stats_routes.py  # Statistics endpoints
@@ -276,7 +276,7 @@ When adding new database fields:
 
 1. **Update the model:**
 ```python
-# models.py
+# pixelprobe/models.py
 class YourModel(db.Model):
     new_field = db.Column(db.String(100))
 ```
@@ -293,6 +293,14 @@ def migrate_database():
 ## Testing
 
 ### Running Tests
+
+Install the test dependencies first, and build the frontend assets (some tests
+and the app itself expect the built static files):
+
+```bash
+pip install -r requirements-test.txt
+npm install && npm run build
+```
 
 ```bash
 # Run all tests
@@ -376,13 +384,12 @@ result = safe_subprocess_run(['ffmpeg', '-i', file_path])
 result = subprocess.run(f'ffmpeg -i {file_path}', shell=True)  # DANGEROUS!
 ```
 
-### Authentication (Future)
+### Authentication
 
-When implementing authentication:
-- Use JWT tokens
-- Implement refresh tokens
-- Add role-based access control
-- Secure sensitive endpoints
+Authentication is implemented in `pixelprobe/auth.py`:
+- Session-based login for the web UI (24-hour lifetime, 30-minute inactivity timeout)
+- Bearer API tokens for programmatic access (managed via `/api/tokens`)
+- Protect new endpoints with the `@auth_required` decorator
 
 ## Contributing
 
@@ -425,7 +432,7 @@ TZ=UTC
 
 2. **Gunicorn Configuration:**
 ```python
-# gunicorn_config.py
+# gunicorn.conf.py
 bind = "0.0.0.0:5000"
 workers = 4
 worker_class = "sync"
@@ -437,7 +444,7 @@ timeout = 120
 
 3. **Run with Gunicorn:**
 ```bash
-gunicorn -c gunicorn_config.py app:app
+gunicorn -c gunicorn.conf.py app:app
 ```
 
 ### Docker Deployment
@@ -478,7 +485,7 @@ docker run -d \
 ### Backup
 
 Regular backups of:
-- SQLite database
+- PostgreSQL database
 - Configuration files
 - Scan results
 - Error logs

--- a/docs/developer/testing-guide.md
+++ b/docs/developer/testing-guide.md
@@ -10,22 +10,22 @@ PixelProbe uses pytest with unit, integration, and performance tests.
 tests/
 ├── conftest.py              # Shared fixtures and test configuration
 ├── test_media_checker.py    # Core media checking functionality tests
+├── test_app.py              # Application-level tests
+├── test_authentication.py   # Auth and API token tests
+├── test_performance.py      # Performance and benchmark tests
+├── ...                      # Other top-level feature tests
 ├── unit/                    # Unit tests for individual components
 │   ├── test_scan_service.py
-│   ├── test_stats_service.py  
-│   ├── test_export_service.py
+│   ├── test_stats_service.py
 │   ├── test_maintenance_service.py
 │   └── test_repositories.py
 ├── integration/             # API endpoint integration tests
-│   ├── test_scan_routes.py
-│   ├── test_stats_routes.py
-│   ├── test_admin_routes.py
-│   └── test_maintenance_routes.py
-├── performance/             # Performance and benchmark tests
-│   └── test_scan_performance.py
-└── fixtures/                # Test data and media samples
-    ├── corrupted/          # Known corrupted media files
-    └── valid/              # Valid media files for testing
+│   ├── test_api_endpoints.py
+│   ├── test_admin_endpoints.py
+│   ├── test_maintenance_endpoints.py
+│   └── test_scan_launch.py
+└── fixtures/                # Test data
+    └── media_samples/       # Media files for testing
 ```
 
 ## Running Tests
@@ -33,6 +33,9 @@ tests/
 ### Basic Test Commands
 
 ```bash
+# Install test dependencies first
+pip install -r requirements-test.txt
+
 # Run all tests
 pytest
 
@@ -113,10 +116,10 @@ Integration tests validate API endpoints and full request/response cycles.
 ```python
 def test_scan_endpoint(client, db):
     """Test full scan workflow via API"""
-    response = client.post('/api/scan-all', 
+    response = client.post('/api/scan',
                           json={'directories': ['/media']})
     assert response.status_code == 200
-    assert response.json['status'] == 'started'
+    assert response.json['status'] == 'queued'
     
     # Verify database state
     scan = ScanState.query.first()
@@ -183,12 +186,12 @@ def mock_scan_result():
 @pytest.fixture
 def corrupted_video():
     """Provide path to corrupted video file"""
-    return 'tests/fixtures/corrupted/broken_video.mp4'
+    return 'tests/fixtures/media_samples/broken_video.mp4'
 
 @pytest.fixture
 def valid_image():
     """Provide path to valid image file"""
-    return 'tests/fixtures/valid/good_image.jpg'
+    return 'tests/fixtures/media_samples/good_image.jpg'
 ```
 
 ## Testing Best Practices
@@ -246,20 +249,21 @@ def test_ffmpeg_error_handling(mock_run):
 
 ```bash
 # Create corrupted video for testing
-dd if=/dev/urandom of=tests/fixtures/corrupted/broken.mp4 bs=1024 count=100
+dd if=/dev/urandom of=tests/fixtures/media_samples/broken.mp4 bs=1024 count=100
 
 # Create valid but small video
 ffmpeg -f lavfi -i testsrc=duration=1:size=320x240:rate=30 \
        -f lavfi -i sine=frequency=1000:duration=1 \
-       -pix_fmt yuv420p tests/fixtures/valid/small.mp4
+       -pix_fmt yuv420p tests/fixtures/media_samples/small.mp4
 ```
 
 ### Test Database
 
-Tests use a PostgreSQL test database that's created fresh for each test run:
+Tests use an in-memory SQLite database (`sqlite:///:memory:`) created fresh
+by the app fixture in `tests/conftest.py`:
 - No persistence between tests
-- Identical schema to production
-- Configure via `TEST_DATABASE_URL` environment variable
+- Same SQLAlchemy models as production
+- No external database or environment variable required
 
 ## Continuous Integration
 

--- a/docs/examples/bash-client.sh
+++ b/docs/examples/bash-client.sh
@@ -12,6 +12,7 @@
 
 # Configuration
 PIXELPROBE_URL="${PIXELPROBE_URL:-http://localhost:5000}"
+PIXELPROBE_API_TOKEN="${PIXELPROBE_API_TOKEN:-}"
 TIMEOUT=30
 
 # Colors for output
@@ -32,12 +33,14 @@ api_request() {
         curl -s -X "$method" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
+            -H "Authorization: Bearer $PIXELPROBE_API_TOKEN" \
             --connect-timeout $TIMEOUT \
             "${PIXELPROBE_URL}${endpoint}"
     else
         curl -s -X "$method" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json" \
+            -H "Authorization: Bearer $PIXELPROBE_API_TOKEN" \
             --connect-timeout $TIMEOUT \
             -d "$data" \
             "${PIXELPROBE_URL}${endpoint}"
@@ -53,6 +56,13 @@ check_dependencies() {
     if ! command -v jq &> /dev/null; then
         echo -e "${RED}❌ Error: jq is not installed${NC}"
         echo "Install with: apt-get install jq (Debian/Ubuntu) or brew install jq (macOS)"
+        exit 1
+    fi
+
+    if [ -z "$PIXELPROBE_API_TOKEN" ]; then
+        echo -e "${RED}Error: PIXELPROBE_API_TOKEN is not set${NC}"
+        echo "Create an API token via POST /api/tokens or the web UI, then:"
+        echo "  export PIXELPROBE_API_TOKEN=<your-token>"
         exit 1
     fi
 }
@@ -89,7 +99,7 @@ cmd_scan() {
     json_dirs=$(printf '%s\n' "${directories[@]}" | jq -R . | jq -s .)
     data=$(jq -n --argjson dirs "$json_dirs" '{directories: $dirs, force_rescan: false}')
     
-    response=$(api_request POST /api/scan-all "$data")
+    response=$(api_request POST /api/scan "$data")
     if [ $? -ne 0 ]; then
         echo -e "${RED}❌ Failed to start scan${NC}"
         exit 1
@@ -159,18 +169,20 @@ cmd_status() {
 cmd_stats() {
     echo -e "${BLUE}📈 Getting statistics...${NC}"
     
-    response=$(api_request GET /api/stats/summary)
-    
+    response=$(api_request GET /api/stats)
+
     total=$(echo "$response" | jq -r '.total_files')
-    scanned=$(echo "$response" | jq -r '.scanned_files')
+    completed=$(echo "$response" | jq -r '.completed_files')
     corrupted=$(echo "$response" | jq -r '.corrupted_files')
-    rate=$(echo "$response" | jq -r '.corruption_rate')
-    
+    healthy=$(echo "$response" | jq -r '.healthy_files')
+    warnings=$(echo "$response" | jq -r '.warning_files')
+
     echo -e "${GREEN}Statistics:${NC}"
     echo "  Total files: $(printf "%'d" $total)"
-    echo "  Scanned: $(printf "%'d" $scanned)"
+    echo "  Completed: $(printf "%'d" $completed)"
     echo "  Corrupted: $(printf "%'d" $corrupted)"
-    echo "  Corruption rate: ${rate}%"
+    echo "  Healthy: $(printf "%'d" $healthy)"
+    echo "  Warnings: $(printf "%'d" $warnings)"
 }
 
 cmd_corrupted() {
@@ -224,8 +236,9 @@ cmd_export() {
     curl -s -X POST \
         -H "Content-Type: application/json" \
         -H "Accept: text/csv" \
-        -d '{"filters": {}}' \
-        "${PIXELPROBE_URL}/api/export/csv" \
+        -H "Authorization: Bearer $PIXELPROBE_API_TOKEN" \
+        -d '{"format": "csv", "filter": "all"}' \
+        "${PIXELPROBE_URL}/api/export" \
         -o "$output_file"
     
     if [ $? -eq 0 ]; then
@@ -238,23 +251,37 @@ cmd_export() {
 }
 
 cmd_cleanup() {
-    local dry_run=${1:-true}
-    
-    echo -e "${BLUE}🧹 Running cleanup (dry_run: $dry_run)...${NC}"
-    
-    data=$(jq -n --arg dr "$dry_run" '{dry_run: ($dr == "true")}')
-    response=$(api_request POST /api/cleanup "$data")
-    
-    missing=$(echo "$response" | jq -r '.missing_files')
-    cleaned=$(echo "$response" | jq -r '.cleaned_files')
-    
-    echo -e "${GREEN}Results:${NC}"
-    echo "  Missing files: $missing"
-    echo "  Cleaned files: $cleaned"
-    
-    if [ "$dry_run" == "true" ] && [ "$missing" -gt 0 ]; then
-        echo -e "${YELLOW}ℹ️  Run with 'false' to actually clean these files${NC}"
+    echo -e "${BLUE}Starting orphaned-entry cleanup...${NC}"
+
+    response=$(api_request POST /api/cleanup-orphaned '{}')
+    error=$(echo "$response" | jq -r '.error // empty')
+
+    if [ -n "$error" ]; then
+        # A 409 is returned when a cleanup is already in progress
+        echo -e "${RED}$error${NC}"
+        exit 1
     fi
+
+    echo -e "${GREEN}$(echo "$response" | jq -r '.message')${NC}"
+
+    # Monitor progress until the cleanup finishes
+    while true; do
+        status_response=$(api_request GET /api/cleanup-status)
+        is_running=$(echo "$status_response" | jq -r '.is_running')
+        phase=$(echo "$status_response" | jq -r '.phase')
+        orphaned=$(echo "$status_response" | jq -r '.orphaned_found')
+        percent=$(echo "$status_response" | jq -r '.progress_percentage // 0')
+
+        if [ "$is_running" != "true" ]; then
+            break
+        fi
+
+        printf "\rPhase: %s (%s%%) - orphaned found: %s" "$phase" "$percent" "$orphaned"
+        sleep 5
+    done
+
+    echo -e "\n${GREEN}Results:${NC}"
+    echo "  Orphaned entries found: $orphaned"
 }
 
 cmd_cancel() {
@@ -276,22 +303,23 @@ Usage: $0 [command] [options]
 
 Commands:
   scan <dirs...>     Scan specified directories
-  status            Show current scan status  
+  status            Show current scan status
   stats             Show overall statistics
   corrupted         List corrupted files
   export <file>     Export results to CSV
-  cleanup [false]   Clean missing files (dry run by default)
+  cleanup           Clean up orphaned database entries
   cancel            Cancel current scan
   help              Show this help message
 
 Environment:
-  PIXELPROBE_URL    PixelProbe API URL (default: http://localhost:5000)
+  PIXELPROBE_URL        PixelProbe API URL (default: http://localhost:5000)
+  PIXELPROBE_API_TOKEN  API token (required; create via POST /api/tokens or the web UI)
 
 Examples:
   $0 scan /media/photos /media/videos
   $0 stats
   $0 export results.csv
-  $0 cleanup false
+  $0 cleanup
 
 EOF
 }
@@ -327,7 +355,7 @@ case "$1" in
         cmd_export "$2"
         ;;
     cleanup)
-        cmd_cleanup "${2:-true}"
+        cmd_cleanup
         ;;
     cancel)
         cmd_cancel

--- a/docs/examples/integration-guide.md
+++ b/docs/examples/integration-guide.md
@@ -3,12 +3,26 @@
 This guide provides examples for integrating PixelProbe into your applications and workflows.
 
 ## Table of Contents
-1. [Basic Integration](#basic-integration)
-2. [Automated Scanning](#automated-scanning)
-3. [Monitoring Integration](#monitoring-integration)
-4. [CI/CD Integration](#cicd-integration)
-5. [Backup System Integration](#backup-system-integration)
-6. [Media Server Integration](#media-server-integration)
+1. [Authentication](#authentication)
+2. [Basic Integration](#basic-integration)
+3. [Automated Scanning](#automated-scanning)
+4. [Monitoring Integration](#monitoring-integration)
+5. [CI/CD Integration](#cicd-integration)
+6. [Backup System Integration](#backup-system-integration)
+7. [Media Server Integration](#media-server-integration)
+
+## Authentication
+
+All API endpoints require authentication. For programmatic access, create an API token
+(via the web UI under Account -> API Tokens, or `POST /api/tokens` with an authenticated
+session) and send it as a Bearer token on every request:
+
+```
+Authorization: Bearer your-api-token
+```
+
+All examples below assume a valid API token. The only endpoint that does not require
+authentication is the liveness probe `GET /healthz`.
 
 ## Basic Integration
 
@@ -22,9 +36,10 @@ from typing import Dict, List, Optional
 class PixelProbeClient:
     """Client for interacting with PixelProbe API"""
     
-    def __init__(self, base_url: str = "http://localhost:5000"):
+    def __init__(self, base_url: str = "http://localhost:5000", api_token: str = ""):
         self.base_url = base_url
         self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {api_token}"})
     
     def scan_file(self, file_path: str) -> Dict:
         """Scan a single file"""
@@ -38,7 +53,7 @@ class PixelProbeClient:
     def scan_directory(self, directories: List[str], force_rescan: bool = False) -> Dict:
         """Scan multiple directories"""
         response = self.session.post(
-            f"{self.base_url}/api/scan-all",
+            f"{self.base_url}/api/scan",
             json={
                 "directories": directories,
                 "force_rescan": force_rescan
@@ -78,13 +93,13 @@ class PixelProbeClient:
     
     def get_statistics(self) -> Dict:
         """Get overall statistics"""
-        response = self.session.get(f"{self.base_url}/api/stats/summary")
+        response = self.session.get(f"{self.base_url}/api/stats")
         response.raise_for_status()
         return response.json()
 
 # Example usage
 if __name__ == "__main__":
-    client = PixelProbeClient()
+    client = PixelProbeClient(api_token="your-api-token")
     
     # Start a scan
     print("Starting scan...")
@@ -108,12 +123,13 @@ if __name__ == "__main__":
 const axios = require('axios');
 
 class PixelProbeClient {
-    constructor(baseUrl = 'http://localhost:5000') {
+    constructor(baseUrl = 'http://localhost:5000', apiToken = '') {
         this.baseUrl = baseUrl;
         this.client = axios.create({
             baseURL: baseUrl,
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiToken}`
             }
         });
     }
@@ -126,7 +142,7 @@ class PixelProbeClient {
     }
     
     async scanDirectory(directories, forceRescan = false) {
-        const response = await this.client.post('/api/scan-all', {
+        const response = await this.client.post('/api/scan', {
             directories: directories,
             force_rescan: forceRescan
         });
@@ -170,7 +186,7 @@ class PixelProbeClient {
 
 // Example usage
 (async () => {
-    const client = new PixelProbeClient();
+    const client = new PixelProbeClient('http://localhost:5000', 'your-api-token');
     
     try {
         // Start scan
@@ -203,18 +219,21 @@ class PixelProbeClient {
 # daily-scan.sh - Run daily media scan and email results
 
 PIXELPROBE_URL="http://localhost:5000"
+API_TOKEN="your-api-token"
+AUTH_HEADER="Authorization: Bearer $API_TOKEN"
 EMAIL="admin@example.com"
 LOG_FILE="/var/log/pixelprobe-daily.log"
 
 # Start scan
 echo "$(date): Starting daily scan" >> "$LOG_FILE"
-SCAN_RESPONSE=$(curl -s -X POST "$PIXELPROBE_URL/api/scan-all" \
+SCAN_RESPONSE=$(curl -s -X POST "$PIXELPROBE_URL/api/scan" \
+    -H "$AUTH_HEADER" \
     -H "Content-Type: application/json" \
     -d '{"force_rescan": false}')
 
 # Wait for completion
 while true; do
-    STATUS=$(curl -s "$PIXELPROBE_URL/api/scan-status")
+    STATUS=$(curl -s -H "$AUTH_HEADER" "$PIXELPROBE_URL/api/scan-status")
     CURRENT_STATUS=$(echo "$STATUS" | jq -r '.status')
     
     if [[ "$CURRENT_STATUS" == "completed" ]] || [[ "$CURRENT_STATUS" == "error" ]]; then
@@ -225,15 +244,16 @@ while true; do
 done
 
 # Get statistics
-STATS=$(curl -s "$PIXELPROBE_URL/api/stats/summary")
+STATS=$(curl -s -H "$AUTH_HEADER" "$PIXELPROBE_URL/api/stats")
 CORRUPTED_COUNT=$(echo "$STATS" | jq -r '.corrupted_files')
 
 # Send email if corrupted files found
 if [[ "$CORRUPTED_COUNT" -gt 0 ]]; then
     # Export corrupted files to CSV
-    curl -X POST "$PIXELPROBE_URL/api/export/csv" \
+    curl -X POST "$PIXELPROBE_URL/api/export" \
+        -H "$AUTH_HEADER" \
         -H "Content-Type: application/json" \
-        -d '{"filters": {"is_corrupted": "true"}}' \
+        -d '{"format": "csv", "filter": "corrupted"}' \
         -o /tmp/corrupted_files.csv
     
     # Send email
@@ -255,8 +275,8 @@ echo "$(date): Scan completed. Corrupted files: $CORRUPTED_COUNT" >> "$LOG_FILE"
 # Run weekly deep scan on Sunday at 3 AM
 0 3 * * 0 /usr/local/bin/weekly-deep-scan.sh
 
-# Clean up missing files monthly
-0 4 1 * * curl -X POST http://localhost:5000/api/cleanup -H "Content-Type: application/json" -d '{"dry_run": false}'
+# Clean up orphaned database entries monthly
+0 4 1 * * curl -X POST http://localhost:5000/api/cleanup-orphaned -H "Authorization: Bearer your-api-token"
 ```
 
 ## Monitoring Integration
@@ -279,14 +299,18 @@ def update_metrics():
     """Update Prometheus metrics from PixelProbe API"""
     try:
         # Get statistics
-        response = requests.get('http://localhost:5000/api/stats/summary')
+        response = requests.get(
+            'http://localhost:5000/api/stats',
+            headers={'Authorization': 'Bearer your-api-token'}
+        )
         stats = response.json()
         
         # Update metrics
         files_total.set(stats['total_files'])
-        files_scanned.set(stats['scanned_files'])
+        files_scanned.set(stats['completed_files'])
         files_corrupted.set(stats['corrupted_files'])
-        corruption_rate.set(stats['corruption_rate'])
+        if stats['completed_files']:
+            corruption_rate.set(stats['corrupted_files'] / stats['completed_files'] * 100)
         
     except Exception as e:
         print(f"Error updating metrics: {e}")
@@ -368,21 +392,26 @@ jobs:
     
     - name: Wait for service
       run: |
-        until curl -s http://localhost:5000/health; do
+        until curl -s http://localhost:5000/healthz; do
           echo "Waiting for PixelProbe..."
           sleep 5
         done
     
     - name: Scan media files
+      env:
+        API_TOKEN: ${{ secrets.PIXELPROBE_API_TOKEN }}
       run: |
-        curl -X POST http://localhost:5000/api/scan-all \
+        curl -X POST http://localhost:5000/api/scan \
+          -H "Authorization: Bearer $API_TOKEN" \
           -H "Content-Type: application/json" \
           -d '{"directories": ["/media"]}'
     
     - name: Wait for scan completion
+      env:
+        API_TOKEN: ${{ secrets.PIXELPROBE_API_TOKEN }}
       run: |
         while true; do
-          STATUS=$(curl -s http://localhost:5000/api/scan-status | jq -r '.status')
+          STATUS=$(curl -s -H "Authorization: Bearer $API_TOKEN" http://localhost:5000/api/scan-status | jq -r '.status')
           if [[ "$STATUS" == "completed" ]]; then
             break
           fi
@@ -390,11 +419,13 @@ jobs:
         done
     
     - name: Check for corrupted files
+      env:
+        API_TOKEN: ${{ secrets.PIXELPROBE_API_TOKEN }}
       run: |
-        CORRUPTED=$(curl -s http://localhost:5000/api/stats/summary | jq -r '.corrupted_files')
+        CORRUPTED=$(curl -s -H "Authorization: Bearer $API_TOKEN" http://localhost:5000/api/stats | jq -r '.corrupted_files')
         if [[ "$CORRUPTED" -gt 0 ]]; then
           echo "[ERROR] Found $CORRUPTED corrupted files!"
-          curl -s http://localhost:5000/api/scan-results?is_corrupted=true | jq -r '.results[].file_path'
+          curl -s -H "Authorization: Bearer $API_TOKEN" "http://localhost:5000/api/scan-results?is_corrupted=true" | jq -r '.results[].file_path'
           exit 1
         else
           echo " No corrupted files found!"
@@ -417,15 +448,16 @@ media-integrity:
     - docker run -d --name pixelprobe -p 5000:5000 -v $CI_PROJECT_DIR/media:/media:ro pixelprobe:latest
     - sleep 10
     - |
-      curl -X POST http://localhost:5000/api/scan-all \
+      curl -X POST http://localhost:5000/api/scan \
+        -H "Authorization: Bearer $PIXELPROBE_API_TOKEN" \
         -H "Content-Type: application/json" \
         -d '{"directories": ["/media"]}'
     - |
-      while [ "$(curl -s http://localhost:5000/api/scan-status | jq -r '.status')" != "completed" ]; do
+      while [ "$(curl -s -H "Authorization: Bearer $PIXELPROBE_API_TOKEN" http://localhost:5000/api/scan-status | jq -r '.status')" != "completed" ]; do
         sleep 10
       done
     - |
-      CORRUPTED=$(curl -s http://localhost:5000/api/stats/summary | jq -r '.corrupted_files')
+      CORRUPTED=$(curl -s -H "Authorization: Bearer $PIXELPROBE_API_TOKEN" http://localhost:5000/api/stats | jq -r '.corrupted_files')
       if [ "$CORRUPTED" -gt 0 ]; then
         echo "Found $CORRUPTED corrupted files"
         exit 1
@@ -453,7 +485,7 @@ from pixelprobe_client import PixelProbeClient
 
 def validate_before_backup(directories):
     """Scan directories and abort backup if corruption found"""
-    client = PixelProbeClient()
+    client = PixelProbeClient(api_token="your-api-token")
     
     print("Starting pre-backup media validation...")
     
@@ -483,7 +515,7 @@ def validate_before_backup(directories):
         print("Please review and fix corrupted files before backup.")
         return False
     
-    print(f" All {stats['scanned_files']} files validated successfully!")
+    print(f" All {stats['completed_files']} files validated successfully!")
     return True
 
 if __name__ == "__main__":
@@ -531,7 +563,7 @@ from pixelprobe_client import PixelProbeClient
 
 def scan_new_media(file_path):
     """Scan newly added media file"""
-    client = PixelProbeClient()
+    client = PixelProbeClient(api_token="your-api-token")
     
     print(f"Scanning new media: {file_path}")
     
@@ -546,7 +578,7 @@ def scan_new_media(file_path):
         # Check if file is corrupted
         scan_results = client.session.get(
             f"{client.base_url}/api/scan-results",
-            params={"file_path": file_path}
+            params={"search": file_path}
         ).json()
         
         if scan_results['results']:
@@ -603,6 +635,7 @@ use OCP\Files\IRootFolder;
 
 class MediaValidator {
     private $pixelprobeUrl = 'http://localhost:5000';
+    private $apiToken = 'your-api-token';
     
     public function validateFile(Node $file) {
         $filePath = $file->getInternalPath();
@@ -615,7 +648,8 @@ class MediaValidator {
             'file_path' => $filePath
         ]));
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            'Content-Type: application/json'
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $this->apiToken
         ]);
         
         $response = curl_exec($ch);
@@ -630,8 +664,11 @@ class MediaValidator {
         sleep(2);
         
         // Check result
-        $ch = curl_init($this->pixelprobeUrl . '/api/scan-results?file_path=' . urlencode($filePath));
+        $ch = curl_init($this->pixelprobeUrl . '/api/scan-results?search=' . urlencode($filePath));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Authorization: Bearer ' . $this->apiToken
+        ]);
         $response = curl_exec($ch);
         curl_close($ch);
         
@@ -674,7 +711,7 @@ services:
       - TZ=${TZ:-UTC}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/examples/integration-guide.md
+++ b/docs/examples/integration-guide.md
@@ -784,9 +784,6 @@ def handle_webhook():
 
 ## Best Practices
 
-1. **Error Handling**: Always implement proper error handling and retries
-2. **Rate Limiting**: Respect API rate limits in your integrations
-3. **Async Operations**: Use async/await for better performance
-4. **Logging**: Log all operations for debugging
-5. **Monitoring**: Set up alerts for corruption detection
-6. **Security**: Use HTTPS in production and implement authentication
+- Respect the API rate limits; back off and retry on 429 responses.
+- Alert on corruption findings (webhook or Prometheus, both shown above) instead of checking manually.
+- Use HTTPS in production.

--- a/docs/examples/nodejs-client.js
+++ b/docs/examples/nodejs-client.js
@@ -8,7 +8,11 @@
  * 
  * Usage:
  *   const PixelProbeClient = require('./pixelprobe-client');
- *   const client = new PixelProbeClient('http://localhost:5000');
+ *   const client = new PixelProbeClient('http://localhost:5000', 30000, '<your-token>');
+ *
+ * Authentication:
+ *   All API endpoints require a Bearer token. Create one via POST /api/tokens
+ *   or the web UI, then pass it as apiToken or set PIXELPROBE_API_TOKEN.
  */
 
 const axios = require('axios');
@@ -28,17 +32,25 @@ class PixelProbeClient {
      * Initialize the PixelProbe client
      * @param {string} baseUrl - Base URL of the PixelProbe API
      * @param {number} timeout - Request timeout in milliseconds
+     * @param {string} apiToken - API token (defaults to PIXELPROBE_API_TOKEN env var)
      */
-    constructor(baseUrl = 'http://localhost:5000', timeout = 30000) {
+    constructor(baseUrl = 'http://localhost:5000', timeout = 30000, apiToken = null) {
         this.baseUrl = baseUrl.replace(/\/$/, '');
         this.timeout = timeout;
-        
+        this.apiToken = apiToken || process.env.PIXELPROBE_API_TOKEN || '';
+
+        if (!this.apiToken) {
+            throw new PixelProbeError(
+                'API token required: pass apiToken or set PIXELPROBE_API_TOKEN');
+        }
+
         this.client = axios.create({
             baseURL: this.baseUrl,
             timeout: this.timeout,
             headers: {
                 'Content-Type': 'application/json',
-                'Accept': 'application/json'
+                'Accept': 'application/json',
+                'Authorization': `Bearer ${this.apiToken}`
             }
         });
         
@@ -74,17 +86,17 @@ class PixelProbeClient {
     }
     
     async scanDirectory(directories, forceRescan = false) {
-        const response = await this.client.post('/api/scan-all', {
+        const response = await this.client.post('/api/scan', {
             directories: directories,
             force_rescan: forceRescan
         });
         return response.data;
     }
-    
-    async scanParallel(directories, numWorkers = 4, forceRescan = false) {
+
+    // Deprecated alias of scanDirectory (POST /api/scan-parallel)
+    async scanParallel(directories, forceRescan = false) {
         const response = await this.client.post('/api/scan-parallel', {
             directories: directories,
-            num_workers: numWorkers,
             force_rescan: forceRescan
         });
         return response.data;
@@ -178,18 +190,21 @@ class PixelProbeClient {
     }
     
     async getStatistics() {
-        const response = await this.client.get('/api/stats/summary');
+        // File counts by state plus integrity coverage
+        const response = await this.client.get('/api/stats');
         return response.data;
     }
-    
-    async getCorruptionByType() {
-        const response = await this.client.get('/api/stats/corruption-by-type');
-        return response.data;
-    }
-    
-    async getScanHistory(days = 30) {
-        const response = await this.client.get('/api/stats/scan-history', {
+
+    async getScanTrends(days = 30) {
+        const response = await this.client.get('/api/stats/trends', {
             params: { days }
+        });
+        return response.data;
+    }
+
+    async getDurationHistogram(days = 30, buckets = 10) {
+        const response = await this.client.get('/api/stats/duration-histogram', {
+            params: { days, buckets }
         });
         return response.data;
     }
@@ -235,29 +250,46 @@ class PixelProbeClient {
     
     // Export operations
     
-    async exportCSV(filters = {}, outputFile = null) {
-        const response = await this.client.post('/api/export/csv', {
-            filters: filters
+    async exportResults(options = {}, outputFile = null) {
+        const {
+            format = 'csv',      // 'csv', 'json', or 'pdf'
+            filter = 'all',      // 'all', 'corrupted', 'healthy', 'warning'
+            search = '',
+            fileIds = []
+        } = options;
+
+        const response = await this.client.post('/api/export', {
+            format: format,
+            filter: filter,
+            search: search,
+            file_ids: fileIds
         }, {
             responseType: 'arraybuffer'
         });
-        
-        const csvData = Buffer.from(response.data);
-        
+
+        const exportData = Buffer.from(response.data);
+
         if (outputFile) {
-            await fs.writeFile(outputFile, csvData);
+            await fs.writeFile(outputFile, exportData);
         }
-        
-        return csvData;
+
+        return exportData;
     }
-    
+
     // Maintenance operations
-    
-    async cleanupMissingFiles(dryRun = true, directories = []) {
-        const response = await this.client.post('/api/cleanup', {
-            dry_run: dryRun,
-            directories: directories
+
+    // Starts a background cleanup of orphaned database entries.
+    // Returns 409 (PixelProbeError) if a cleanup is already in progress;
+    // monitor progress with getCleanupStatus().
+    async cleanupOrphaned(filePaths = []) {
+        const response = await this.client.post('/api/cleanup-orphaned', {
+            file_paths: filePaths
         });
+        return response.data;
+    }
+
+    async getCleanupStatus() {
+        const response = await this.client.get('/api/cleanup-status');
         return response.data;
     }
     
@@ -316,9 +348,10 @@ async function main() {
             const stats = await client.getStatistics();
             console.log('\n📈 Statistics:');
             console.log(`   Total files: ${stats.total_files.toLocaleString()}`);
-            console.log(`   Scanned: ${stats.scanned_files.toLocaleString()}`);
+            console.log(`   Completed: ${stats.completed_files.toLocaleString()}`);
             console.log(`   Corrupted: ${stats.corrupted_files.toLocaleString()}`);
-            console.log(`   Corruption rate: ${stats.corruption_rate.toFixed(2)}%`);
+            console.log(`   Healthy: ${stats.healthy_files.toLocaleString()}`);
+            console.log(`   Warnings: ${stats.warning_files.toLocaleString()}`);
         }
         
         if (args.includes('--corrupted')) {
@@ -345,7 +378,7 @@ async function main() {
             }
             
             console.log(`\n💾 Exporting results to ${outputFile}`);
-            await client.exportCSV({}, outputFile);
+            await client.exportResults({ format: 'csv' }, outputFile);
             console.log('✅ Export complete');
         }
         
@@ -362,7 +395,8 @@ Options:
   --help             Show this help message
 
 Environment:
-  PIXELPROBE_URL     PixelProbe API URL (default: http://localhost:5000)
+  PIXELPROBE_URL        PixelProbe API URL (default: http://localhost:5000)
+  PIXELPROBE_API_TOKEN  API token (required; create via POST /api/tokens or the web UI)
 `);
         }
         

--- a/docs/examples/python-client.py
+++ b/docs/examples/python-client.py
@@ -8,11 +8,16 @@ Requirements:
 
 Usage:
     from pixelprobe_client import PixelProbeClient
-    
-    client = PixelProbeClient("http://localhost:5000")
+
+    client = PixelProbeClient("http://localhost:5000", api_token="<your-token>")
     client.scan_directory(["/media/photos"])
+
+Authentication:
+    All API endpoints require a Bearer token. Create one via POST /api/tokens
+    or the web UI, then pass it as api_token or set PIXELPROBE_API_TOKEN.
 """
 
+import os
 import requests
 import time
 import json
@@ -37,20 +42,27 @@ class PixelProbeClient:
         corrupted = client.get_corrupted_files()
     """
     
-    def __init__(self, base_url: str = "http://localhost:5000", timeout: int = 30):
+    def __init__(self, base_url: str = "http://localhost:5000", timeout: int = 30,
+                 api_token: Optional[str] = None):
         """
         Initialize the PixelProbe client
-        
+
         Args:
             base_url: Base URL of the PixelProbe API
             timeout: Request timeout in seconds
+            api_token: API token (defaults to PIXELPROBE_API_TOKEN env var)
         """
         self.base_url = base_url.rstrip('/')
         self.timeout = timeout
+        self.api_token = api_token or os.environ.get('PIXELPROBE_API_TOKEN', '')
+        if not self.api_token:
+            raise PixelProbeException(
+                "API token required: pass api_token or set PIXELPROBE_API_TOKEN")
         self.session = requests.Session()
         self.session.headers.update({
             'Content-Type': 'application/json',
-            'Accept': 'application/json'
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {self.api_token}'
         })
     
     def _request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
@@ -103,28 +115,25 @@ class PixelProbeClient:
         Returns:
             Response with scan status
         """
-        response = self._request('POST', '/api/scan-all', json={
+        response = self._request('POST', '/api/scan', json={
             'directories': directories,
             'force_rescan': force_rescan
         })
         return response.json()
-    
-    def scan_parallel(self, directories: List[str], num_workers: int = 4, 
-                     force_rescan: bool = False) -> Dict:
+
+    def scan_parallel(self, directories: List[str], force_rescan: bool = False) -> Dict:
         """
-        Start a parallel scan with multiple workers
-        
+        Deprecated alias of scan_directory (POST /api/scan-parallel)
+
         Args:
             directories: List of directory paths to scan
-            num_workers: Number of parallel workers (1-16)
             force_rescan: Force rescan of already scanned files
-            
+
         Returns:
             Response with scan status
         """
         response = self._request('POST', '/api/scan-parallel', json={
             'directories': directories,
-            'num_workers': num_workers,
             'force_rescan': force_rescan
         })
         return response.json()
@@ -211,19 +220,22 @@ class PixelProbeClient:
         return all_files
     
     def get_statistics(self) -> Dict:
-        """Get overall statistics summary"""
-        response = self._request('GET', '/api/stats/summary')
+        """Get overall statistics (file counts by state plus integrity coverage)"""
+        response = self._request('GET', '/api/stats')
         return response.json()
-    
-    def get_corruption_by_type(self) -> List[Dict]:
-        """Get corruption statistics by file type"""
-        response = self._request('GET', '/api/stats/corruption-by-type')
-        return response.json()
-    
-    def get_scan_history(self, days: int = 30) -> List[Dict]:
-        """Get scan history for the specified number of days"""
-        response = self._request('GET', '/api/stats/scan-history', params={
+
+    def get_scan_trends(self, days: int = 30) -> Dict:
+        """Get scan counter metrics over the specified number of days (max 365)"""
+        response = self._request('GET', '/api/stats/trends', params={
             'days': days
+        })
+        return response.json()
+
+    def get_duration_histogram(self, days: int = 30, buckets: int = 10) -> Dict:
+        """Get scan duration histogram for the specified number of days"""
+        response = self._request('GET', '/api/stats/duration-histogram', params={
+            'days': days,
+            'buckets': buckets
         })
         return response.json()
     
@@ -268,46 +280,60 @@ class PixelProbeClient:
     
     # Export Operations
     
-    def export_csv(self, filters: Optional[Dict] = None, output_file: str = None) -> bytes:
+    def export_results(self, format: str = 'csv', filter: str = 'all',
+                       search: str = '', file_ids: Optional[List[int]] = None,
+                       output_file: str = None) -> bytes:
         """
-        Export scan results to CSV
-        
+        Export scan results to CSV, JSON, or PDF
+
         Args:
-            filters: Optional filters (scan_status, is_corrupted, start_date, end_date)
-            output_file: Optional file path to save CSV
-            
+            format: Output format ('csv', 'json', 'pdf')
+            filter: Filter type ('all', 'corrupted', 'healthy', 'warning')
+            search: Search term to filter file paths
+            file_ids: Optional list of specific file IDs to export
+            output_file: Optional file path to save the export
+
         Returns:
-            CSV data as bytes
+            Export data as bytes
         """
-        response = self._request('POST', '/api/export/csv', 
-                               json={'filters': filters or {}})
-        
-        csv_data = response.content
-        
+        response = self._request('POST', '/api/export', json={
+            'format': format,
+            'filter': filter,
+            'search': search,
+            'file_ids': file_ids or []
+        })
+
+        export_data = response.content
+
         if output_file:
             with open(output_file, 'wb') as f:
-                f.write(csv_data)
-        
-        return csv_data
+                f.write(export_data)
+
+        return export_data
     
     # Maintenance Operations
     
-    def cleanup_missing_files(self, dry_run: bool = True, 
-                            directories: Optional[List[str]] = None) -> Dict:
+    def cleanup_orphaned(self, file_paths: Optional[List[str]] = None) -> Dict:
         """
-        Clean up database entries for missing files
-        
+        Start cleanup of orphaned database entries (runs in the background)
+
+        Returns 409 (PixelProbeException) if a cleanup is already in progress.
+        Monitor progress with get_cleanup_status().
+
         Args:
-            dry_run: If True, only report what would be cleaned
-            directories: Optional list of directories to check
-            
+            file_paths: Optional list of specific file paths to clean up
+
         Returns:
-            Cleanup results
+            Response with status, message, and cleanup_id
         """
-        response = self._request('POST', '/api/cleanup', json={
-            'dry_run': dry_run,
-            'directories': directories or []
+        response = self._request('POST', '/api/cleanup-orphaned', json={
+            'file_paths': file_paths or []
         })
+        return response.json()
+
+    def get_cleanup_status(self) -> Dict:
+        """Get current cleanup operation status and progress"""
+        response = self._request('GET', '/api/cleanup-status')
         return response.json()
     
     def vacuum_database(self) -> Dict:
@@ -321,8 +347,10 @@ def main():
     import argparse
     
     parser = argparse.ArgumentParser(description='PixelProbe Client')
-    parser.add_argument('--url', default='http://localhost:5000', 
+    parser.add_argument('--url', default='http://localhost:5000',
                        help='PixelProbe API URL')
+    parser.add_argument('--token', default=None,
+                       help='API token (default: PIXELPROBE_API_TOKEN env var)')
     parser.add_argument('--scan', nargs='+', help='Directories to scan')
     parser.add_argument('--status', action='store_true', 
                        help='Show current scan status')
@@ -335,7 +363,7 @@ def main():
     args = parser.parse_args()
     
     # Initialize client
-    client = PixelProbeClient(args.url)
+    client = PixelProbeClient(args.url, api_token=args.token)
     
     try:
         # Check health
@@ -369,9 +397,10 @@ def main():
             stats = client.get_statistics()
             print("\n📈 Statistics:")
             print(f"   Total files: {stats['total_files']:,}")
-            print(f"   Scanned: {stats['scanned_files']:,}")
+            print(f"   Completed: {stats['completed_files']:,}")
             print(f"   Corrupted: {stats['corrupted_files']:,}")
-            print(f"   Corruption rate: {stats['corruption_rate']:.2f}%")
+            print(f"   Healthy: {stats['healthy_files']:,}")
+            print(f"   Warnings: {stats['warning_files']:,}")
         
         if args.corrupted:
             # List corrupted files
@@ -385,7 +414,7 @@ def main():
         if args.export:
             # Export to CSV
             print(f"\n💾 Exporting results to {args.export}")
-            client.export_csv(output_file=args.export)
+            client.export_results(format='csv', output_file=args.export)
             print("✅ Export complete")
     
     except PixelProbeException as e:

--- a/docs/maintenance/TOOLS_AND_SCRIPTS.md
+++ b/docs/maintenance/TOOLS_AND_SCRIPTS.md
@@ -178,7 +178,7 @@ python3 tests/fixtures/media_samples/download_missing_samples.py
 ```bash
 ./tools/delete_files_from_csv.sh corrupted_files.csv
 ```
-** Warning:** This permanently deletes files!
+**Warning:** This permanently deletes files!
 
 #### `tools/reset_nal_files_direct.sh`
 **Purpose:** Direct database reset of NAL-flagged files  
@@ -195,17 +195,17 @@ python3 tests/fixtures/media_samples/download_missing_samples.py
    python3 tools/fix_gif_header_false_positives.py
    ```
 
-3. **Check database health:**
+2. **Check database health:**
    ```bash
    python3 scripts/check_db_integrity.py
    ```
 
-4. **Create test database:**
+3. **Create test database:**
    ```bash
    python3 scripts/create_test_database.py
    ```
 
-5. **Run tests:**
+4. **Run tests:**
    ```bash
    pytest tests/
    ```

--- a/docs/maintenance/TOOLS_AND_SCRIPTS.md
+++ b/docs/maintenance/TOOLS_AND_SCRIPTS.md
@@ -123,21 +123,6 @@ These tools fix common false positives in media file corruption detection:
 ./scripts/setup_and_run_local.sh
 ```
 
-#### `scripts/run_modern_ui.sh`
-**Purpose:** Run the modern UI in development mode  
-
-#### `scripts/run_test_ui.sh`
-**Purpose:** Run UI with test fixtures  
-
-### Docker Development
-
-#### `scripts/docker-run-modern.sh`
-**Purpose:** Run modern UI in Docker container  
-**Usage:**
-```bash
-./scripts/docker-run-modern.sh
-```
-
 ---
 
 ## Testing Tools
@@ -200,15 +185,6 @@ python3 tests/fixtures/media_samples/download_missing_samples.py
 
 ---
 
-## Runtime Patches
-
-#### `patches/v2_2_47_fixes.py`
-**Purpose:** Runtime patches for v2.2.47 connection issues  
-**Applied:** Automatically on startup  
-**Fixes:** Connection pooling, transaction recovery  
-
----
-
 ## Quick Reference
 
 ### Most Common Operations
@@ -253,7 +229,6 @@ Most scripts respect these environment variables:
 
 **Development Only:**
 - Test database creators
-- UI development scripts
 - Local setup scripts
 
 **Use with Caution:**
@@ -267,5 +242,5 @@ Most scripts respect these environment variables:
 For issues with any script:
 1. Check the script's docstring for usage
 2. Run with `--help` flag if available
-3. Check logs in `/app/instance/logs/`
+3. Check application logs via the web UI or `GET /api/logs` (logs are stored in the LogEntry database table)
 4. Report issues at https://github.com/ttlequals0/PixelProbe/issues

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1622,7 +1622,7 @@ paths:
                     type: string
                 scan_type:
                   type: string
-                  enum: [full, parallel]
+                  enum: [full, parallel, file_changes, orphan]
                   default: full
                 force_rescan:
                   type: boolean
@@ -2044,73 +2044,6 @@ paths:
         '404':
           description: Pattern not found
 
-  /configurations:
-    get:
-      summary: Get all configurations
-      description: |
-        Get all scan configurations.
-
-        **Example:**
-        ```bash
-        curl -X GET http://your-server/api/configurations \
-          -H "Authorization: Bearer YOUR_TOKEN"
-        ```
-      tags: [Configuration]
-      responses:
-        '200':
-          description: Configurations retrieved successfully
-
-    post:
-      summary: Add configuration
-      description: |
-        Add a new configuration.
-
-        **Example:**
-        ```bash
-        curl -X POST http://your-server/api/configurations \
-          -H "Authorization: Bearer YOUR_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d '{"path": "/media/music"}'
-        ```
-      tags: [Configuration]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [path]
-              properties:
-                path:
-                  type: string
-      responses:
-        '200':
-          description: Configuration added successfully
-
-  /configurations/{config_id}:
-    delete:
-      summary: Delete configuration
-      description: |
-        Delete a configuration entry by ID.
-
-        **Example:**
-        ```bash
-        curl -X DELETE http://your-server/api/configurations/3 \
-          -H "Authorization: Bearer YOUR_TOKEN"
-        ```
-      tags: [Configuration]
-      parameters:
-        - name: config_id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: Configuration deleted successfully
-        '404':
-          description: Configuration not found
-
   /exclusions:
     get:
       summary: Get exclusion settings
@@ -2344,7 +2277,7 @@ paths:
               properties:
                 format:
                   type: string
-                  enum: [csv, json, excel, pdf]
+                  enum: [csv, json, pdf]
                 filter:
                   type: string
                   enum: [all, corrupted, healthy, pending, warning]

--- a/pixelprobe/media_checker.py
+++ b/pixelprobe/media_checker.py
@@ -65,6 +65,10 @@ _RE_BLACK_START = re.compile(r'black_start:\s*([\d.]+)')
 _RE_BLACK_END = re.compile(r'black_end:\s*([\d.]+)')
 _RE_BLACK_DURATION = re.compile(r'black_duration:\s*([\d.]+)')
 
+# ImageMagick 7 renamed the CLI to 'magick' ('convert' survives only as a
+# compatibility alias); prefer it, fall back for ImageMagick 6 systems.
+IMAGEMAGICK_BINARY = 'magick' if shutil.which('magick') else 'convert'
+
 def get_default_filename_patterns():
     """Get default filename patterns to exclude"""
     return [
@@ -1002,8 +1006,8 @@ class PixelProbe:
             # Using 'convert' instead of 'identify' to validate PIXEL DATA, not just headers
             # This forces ImageMagick to decode the entire image, detecting deeper corruption
             result = safe_subprocess_run(
-                ['convert',
-                 ensure_cli_safe_path(file_path),  # convert has no '--' separator; './'-prefix relative paths
+                [IMAGEMAGICK_BINARY,
+                 ensure_cli_safe_path(file_path),  # no '--' separator support; './'-prefix relative paths
                  '-regard-warnings',      # Treat warnings as errors for strict validation
                  'null:'],                # Null output (discard result, we only check for errors)
                 capture_output=True,
@@ -1052,7 +1056,8 @@ class PixelProbe:
             elif result.stderr:
                 # Check if this is just a metadata/profile warning (not actual corruption)
                 stderr_lower = result.stderr.lower()
-                is_profile_warning = 'corruptimageprofile' in stderr_lower and '@warning/profile.c' in stderr_lower
+                # Note: ImageMagick emits "@ warning/profile.c" (space after @)
+                is_profile_warning = 'corruptimageprofile' in stderr_lower and 'warning/profile.c' in stderr_lower
                 
                 # Check for PNG chunk warnings that aren't actual corruption
                 png_chunk_warnings = [
@@ -1064,7 +1069,7 @@ class PixelProbe:
                     'time chunk',
                     'bkgd chunk'
                 ]
-                is_png_warning = any(warning in stderr_lower for warning in png_chunk_warnings) and '@warning/png.c' in stderr_lower
+                is_png_warning = any(warning in stderr_lower for warning in png_chunk_warnings) and 'warning/png.c' in stderr_lower
                 
                 if is_profile_warning:
                     # Profile warnings (like XMP) don't indicate actual image corruption
@@ -2157,7 +2162,9 @@ class PixelProbe:
                 'ffprobe',
                 '-f', 'lavfi',
                 '-i', f'movie={file_path},signalstats=stat=tout+vrep',
-                '-show_entries', 'frame=pkt_pts_time:frame_tags=lavfi.signalstats.TOUT,lavfi.signalstats.VREP',
+                # pts_time (pkt_pts_time was removed in newer ffmpeg; pts_time
+                # exists on 6.x and 8.x alike)
+                '-show_entries', 'frame=pts_time:frame_tags=lavfi.signalstats.TOUT,lavfi.signalstats.VREP',
                 '-of', 'csv=p=0',
                 '-v', 'quiet'
             ], capture_output=True, text=True, timeout=60)

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.6.65'
+_DEFAULT_VERSION = '2.7.0'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2235,16 +2235,16 @@ class PixelProbeApp {
         // Setup close handlers
         const closeBtn = modal.querySelector('.modal-close');
         if (closeBtn) {
-            closeBtn.onclick = () => modal.style.display = 'none';
+            closeBtn.onclick = () => this.closeModal('media-viewer-modal');
         }
-        
+
         // Close on outside click
         modal.onclick = (e) => {
             if (e.target === modal) {
-                modal.style.display = 'none';
+                this.closeModal('media-viewer-modal');
             }
         };
-        
+
     }
 
     async rescanFile(fileId) {
@@ -4666,8 +4666,20 @@ class PixelProbeApp {
     closeModal(modalId) {
         const modal = document.querySelector(`#${modalId}`);
         if (modal) {
+            this.stopModalMedia(modal);
             modal.style.display = 'none';
         }
+    }
+
+    stopModalMedia(modal) {
+        // A hidden <video>/<audio> keeps playing audio in the background;
+        // pause and detach sources so playback and buffering actually stop
+        modal.querySelectorAll('video, audio').forEach((media) => {
+            media.pause();
+            media.removeAttribute('src');
+            media.querySelectorAll('source').forEach((s) => s.removeAttribute('src'));
+            media.load();
+        });
     }
 
 }

--- a/tests/fixtures/media_samples/download_missing_samples.py
+++ b/tests/fixtures/media_samples/download_missing_samples.py
@@ -2,6 +2,7 @@
 """Download missing media samples from FFmpeg samples."""
 
 import os
+import shutil
 import subprocess
 import urllib.request
 
@@ -96,7 +97,8 @@ def main():
         for ext in ['heic', 'heif']:
             if not os.path.exists(f'valid.{ext}'):
                 try:
-                    subprocess.run(['convert', 'valid.jpg', f'valid.{ext}'], check=True)
+                    im_binary = 'magick' if shutil.which('magick') else 'convert'
+                    subprocess.run([im_binary, 'valid.jpg', f'valid.{ext}'], check=True)
                     print(f"✓ Created valid.{ext}")
                 except Exception as e:
                     print(f"✗ Failed to create valid.{ext}: {e}")

--- a/tools/fix_imagemagick_profile_warnings.py
+++ b/tools/fix_imagemagick_profile_warnings.py
@@ -27,7 +27,7 @@ def generate_fix_sql():
     AND scan_tool = 'imagemagick'
     AND (
         corruption_details LIKE '%CorruptImageProfile%' 
-        OR scan_output LIKE '%CorruptImageProfile%@warning/profile.c%'
+        OR scan_output LIKE '%CorruptImageProfile%warning/profile.c%'
     );
     """
     
@@ -82,7 +82,7 @@ def generate_fix_sql():
     WHERE is_corrupted = 1 
     AND (
         corruption_details LIKE '%ImageMagick warnings: %CorruptImageProfile%' 
-        OR scan_output LIKE '%CorruptImageProfile%@warning/profile.c%'
+        OR scan_output LIKE '%CorruptImageProfile%warning/profile.c%'
     )
     AND corruption_details LIKE '%;%';
     """


### PR DESCRIPTION
Fixes #67.

## Base image: Ubuntu 24.04 to 26.04

- FFmpeg 6.1.1 becomes 8.0.1, ImageMagick 6.9 becomes 7.1.2 (Q16, non-HDRI variant).
- Ubuntu 26.04 ships Python 3.14; the app pins 3.12 via deadsnakes and runs from /opt/venv (psycopg2-binary has no 3.14 wheels, and 3.12 matches the tested CI matrix). Same pattern MinusPod used for its 26.04 upgrade.
- The image checker now invokes `magick` when present, falling back to `convert` on ImageMagick 6 systems (Ubuntu's IM7 packages keep `convert` as an alternatives symlink, but IM7 upstream deprecates it).
- The temporal-outlier ffprobe call uses `pts_time` - `pkt_pts_time` was removed in newer FFmpeg, which silently disabled that corruption signal (the parser fails soft).
- ImageMagick policy edits target /etc/ImageMagick-7 with a build-time assertion so a silent sed no-op fails the build instead of shipping default resource limits. The 26.04 policy has no PDF/HEIC coder blocks, so the old un-blocking seds are gone.
- linux-libc-dev and build headers are purged from the final image, which clears the long tail of unfixable kernel-header CVEs from scanners. The unused pebble binary in the 26.04 rootfs is removed for the same reason.

Bonus fix found during verification: the gates that classify benign ImageMagick PNG/profile warnings checked for `@warning/png.c`, but ImageMagick 6 and 7 both emit `@ warning/png.c` with a space - the benign paths were unreachable since they were written. Fixed here and in tools/fix_imagemagick_profile_warnings.py.

## Valkey 9 (drop-in Redis replacement)

docker-compose broker image becomes `valkey/valkey:9-alpine`. The service name, all redis:// URLs, and the wire protocol are unchanged; the code uses plain RESP plus one EVAL script, all supported. The Valkey image ships redis-* compatibility symlinks.

## PostgreSQL 18 (BREAKING compose default)

- compose default becomes `postgres:18-alpine`. A 15-era `postgres_data` volume will not start on the 18 image - a tested dump/restore migration guide is in docs/DOCKER_SETUP.md, and README carries the warning. Users can pin `postgres:15-alpine` to defer; the app supports 15 through 18.
- Found during verification: the postgres 18+ Docker images also moved the expected volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql` (major-version subdirectories, enabling `pg_upgrade --link`) and refuse to start with a mount at the old path. The compose file and guide cover this.

## CI

New `image-integration` job builds the Docker image and runs the real-media parser tests inside it. The ffmpeg/ImageMagick stderr parsers fail soft (a format change yields zero detections, not an error), so only testing against the shipped binaries catches base-image regressions.

## Verification

- Real-media suite inside the new image: 10/10 pass, including corruption detection, MP3 broken frames, invalid AIFF, and corrupted images on ffmpeg 8 / ImageMagick 7.
- freezedetect/blackdetect log formats and the `@ warning/png.c` token verified against real ffmpeg 8 / IM7 output; `-regard-warnings` exit-code differences between IM6 and IM7 traced through the classification paths (net effect: fewer false positives, warning-class corruption still caught).
- Fresh compose stack (postgres:18 + valkey:9 + this image): all containers healthy, admin setup, full scan via API - 5 sample files, exactly the 2 planted corrupt files flagged (ffmpeg and imagemagick respectively), scheduler lock held by the celery worker through Valkey.
- Migration guide dry-run: 5000 rows dumped from postgres:15, restored into 18.4, row counts match, collation refresh clean.
- Host suite: 475 passed, 8 skipped. Frontend builds.

## Media viewer: closing the player now stops playback

Closing the viewer modal only hid it, so a playing video or audio file kept playing in the background. closeModal() now pauses any media in the modal and detaches its sources; both close paths (X button, outside click) route through it. Verified in-browser: playback stops and sources detach for video and audio.

## Documentation accuracy audit

Every doc was audited against the codebase and corrected (60+ findings). The worst offenders documented endpoints that never existed (/api/scan-all, /api/stats/summary, /api/scan/parallel-v2*, /api/export/csv, /api/cleanup) with no authentication; DOCKER_SETUP.md's example compose could not have booted (nonexistent celery_app module, authenticated /health as healthcheck, missing SECRET_KEY); CONFIGURATION.md described a Celery beat and four queues that do not exist; PERFORMANCE_TUNING.md tuned env vars that appear nowhere in the code. All example clients now authenticate and call real endpoints. openapi.yaml lost a duplicate path key and a nonexistent DELETE route. A hardcoded deployment hostname was removed from FIX_INCOMPLETE_SCANS.md. The PostgreSQL 15-to-18 migration guide is linked from the README docs index and the Requirements upgrade warning.
