### PR TITLE
Dashboard: pending filter, bitrot card, aligned card order (v2.7.2)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.7.2] - 2026-07-16
+
+### Added
+
+- **Pending Only filter button (#72).** The dashboard showed a pending-files count but offered no way to list them; the results API already accepted `scan_status=pending`, so the button just exposes it. Useful for seeing exactly which files a scan has not gotten to - or, after an incident like #70, which files never completed.
+- **Bitrot Suspected stat card (#72).** The count was already in the stats payload (and buried in the integrity card's tooltip) but had no card of its own despite having a filter button.
+
+### Changed
+
+- **Dashboard stat cards reordered to mirror the filter buttons (#72):** total, corrupted, warnings, bitrot, healthy, pending, with integrity coverage last. The cards remain read-only stats; they are deliberately not clickable filters.
+
 ## [2.7.1] - 2026-07-16
 
 ### Fixed

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.7.1'
+_DEFAULT_VERSION = '2.7.2'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -358,6 +358,7 @@ class StatsDashboard {
         this.updateStatCard('healthy-files', stats.healthy_files);
         this.updateStatCard('corrupted-files', stats.corrupted_files);
         this.updateStatCard('warning-files', stats.warning_files || 0);
+        this.updateStatCard('bitrot-files', (stats.integrity && stats.integrity.bitrot_suspected) || 0);
         this.updateStatCard('pending-files', stats.pending_files);
         this.updateStatCard('scanning-files', stats.scanning_files);
         this.renderIntegrityCoverage(stats.integrity);
@@ -1208,6 +1209,9 @@ class TableManager {
                         break;
                     case 'bitrot':
                         params.bitrot_suspected = 'true';
+                        break;
+                    case 'pending':
+                        params.scan_status = 'pending';
                         break;
                     case 'all':
                     default:

--- a/templates/index.html
+++ b/templates/index.html
@@ -172,14 +172,12 @@
                 </div>
                 
                 <!-- Stats Grid -->
+                <!-- Card order mirrors the filter buttons below: total/all,
+                     corrupted, warnings, bitrot, healthy, pending -->
                 <div class="stats-grid" role="region" aria-label="File statistics summary">
                     <div class="stat-card" role="group" aria-label="Total files">
                         <div class="stat-value" id="total-files" aria-live="polite">0</div>
                         <div class="stat-label">Total Files</div>
-                    </div>
-                    <div class="stat-card" role="group" aria-label="Healthy files">
-                        <div class="stat-value" id="healthy-files" aria-live="polite">0</div>
-                        <div class="stat-label">Healthy Files</div>
                     </div>
                     <div class="stat-card" role="group" aria-label="Corrupted files">
                         <div class="stat-value" id="corrupted-files" aria-live="polite">0</div>
@@ -188,6 +186,14 @@
                     <div class="stat-card">
                         <div class="stat-value" id="warning-files">0</div>
                         <div class="stat-label">Warning Files</div>
+                    </div>
+                    <div class="stat-card" role="group" aria-label="Bitrot suspected files">
+                        <div class="stat-value" id="bitrot-files" aria-live="polite">0</div>
+                        <div class="stat-label">Bitrot Suspected</div>
+                    </div>
+                    <div class="stat-card" role="group" aria-label="Healthy files">
+                        <div class="stat-value" id="healthy-files" aria-live="polite">0</div>
+                        <div class="stat-label">Healthy Files</div>
                     </div>
                     <div class="stat-card">
                         <div class="stat-value" id="pending-files">0</div>
@@ -219,6 +225,9 @@
                                     </button>
                                     <button class="btn btn-secondary" data-filter="healthy">
                                         Healthy Only
+                                    </button>
+                                    <button class="btn btn-secondary" data-filter="pending">
+                                        Pending Only
                                     </button>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary

Addresses the actionable parts of #72.

- **Pending Only filter button.** The dashboard showed a pending-files count with no way to list them. The results API already accepted `scan_status=pending`, so this just exposes it. Handy for seeing which files a running scan hasn't reached - or which files never completed after an incident.
- **Bitrot Suspected stat card.** The count was already in the stats payload but only surfaced inside the integrity card's tooltip, despite bitrot having its own filter button.
- **Card order now mirrors the filter buttons:** total, corrupted, warnings, bitrot, healthy, pending, with integrity coverage last.

The fourth suggestion in #72 (clickable cards that sync with the filter buttons) is deliberately not included: the cards are read-only stats, and the two sets don't map 1:1 (integrity coverage is a percentage, not a file list).

## Version

2.7.2

## Test plan

- [x] Webpack production build succeeds
- [x] Suite: 486 passed, 8 skipped (one timing-based perf test flaked under full-suite load and passes in isolation; unrelated to this frontend-only diff)
- [ ] CI and CodeQL green