### PR TITLE
Chunk heartbeat, scan revival, light-mode UI fixes (v2.7.3)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.7.3] - 2026-07-17
+
+### Fixed
+
+- **Scans busy on long movies are no longer falsely marked crashed (#75).** The stuck-scan check crashes any scan with no progress update for 30 minutes, but progress was only written when a file finished - and a single large movie can legitimately spend 30-60+ minutes inside ffmpeg validation, so a run of big files tripped the rule while the workers were healthy. Each chunk task now runs a heartbeat thread that bumps the scan's liveness timestamp every `CHUNK_HEARTBEAT_INTERVAL_SECS` (default 120s), so `last_update` staleness now genuinely means the workers are dead. Note the semantics change: `last_update` is a liveness heartbeat now, not a last-file-completed timestamp.
+- **Scans interrupted by container restarts now resume instead of dying (#75).** Restarting the stack mid-scan could lose the queued chunk tasks; startup kept the scan alive ("within grace") but nothing ever re-queued its chunks, so it sat idle until the 30-minute rule crashed it. The stuck-scan sweeper now detects this state - stale heartbeat with chunk rows still active - reclaims the dead workers' claimed files, and re-dispatches the chunks (up to 3 revival attempts, staleness threshold `CHUNK_REVIVE_STALENESS_SECS`, default 600s). Duplicate-delivery guards make revival safe against ghost redeliveries: a task whose chunk is already finished or owned by a newer task id exits without touching anything, which also fixes a latent bug where a redelivered message could reset a completed chunk and zero its file count. Chunk task ids are now assigned before dispatch (previously written after, from the group result), and the discovery walk heartbeats too, so a slow sparse-tree walk cannot be falsely crashed either.
+- **Worker crash mid-chunk no longer silently drops files.** With late acks, a chunk whose worker died mid-scan is redelivered under the same task id - but its files were already claimed, so the redelivery found nothing pending and marked the chunk complete with zero files, dropping the in-flight files from the scan. The redelivery now reclaims the dead attempt's files and scans them.
+- **Cancel button invisible in light mode (#74).** The button referenced a CSS variable that was never defined, so its background resolved to transparent - white text on a white page. Same fix applied to the pagination hover background, which had the identical defect.
+- **"Files by type" chart unreadable in light mode (#74).** Axis labels, title, and grid lines were hardcoded to dark-theme colors. They now read the active theme's CSS variables at render time, and the file-type labels got a bump from 10px to 11px in both themes.
+- **Integrity check started during a running scan no longer strands the UI (#74).** The progress panel can only track one operation at a time; when an integrity check finished, it stopped all polling and left the scan buttons disabled with no way back. On completion the UI now checks whether a scan is still running and returns to its progress view, or re-enables the scan buttons if not. Switching operations also no longer leaks a duplicate poll loop.
+
 ## [2.7.2] - 2026-07-16
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -63,6 +63,8 @@ All configuration is done via environment variables, either in `.env` file or di
 | `OUTPUT_ROTATION_ENABLED` | `true` | Enable output truncation | `true` for large scans |
 | `FREEZE_DETECTION_ENABLED` | `true` | Enable video freeze detection (freezedetect + blackdetect) | `false` to skip and reduce scan time |
 | `FILE_READ_TIMEOUT_SECS` | `60` | Deadline in seconds for raw file reads (stat, type detection, hash). A file whose reads stall past it (dead network mount, failing sector) is marked corrupted and skipped instead of hanging the scan. The hash deadline scales up with file size assuming at least 5MB/s storage throughput | Raise the base on storage slower than 5MB/s sustained |
+| `CHUNK_HEARTBEAT_INTERVAL_SECS` | `120` | How often a running chunk task bumps the scan's liveness timestamp. Keeps a scan busy on one long movie from being falsely marked crashed by the 30-minute stuck-scan rule | Leave at default unless debugging |
+| `CHUNK_REVIVE_STALENESS_SECS` | `600` | How stale the scan liveness timestamp must be before the stuck-scan sweeper treats the chunk workers as gone and re-queues their chunks (recovers scans interrupted by container restarts) | Must exceed several heartbeat intervals |
 | `FFPROBE_TIMEOUT_SECS` | `120` | Hard ceiling in seconds for ffprobe metadata reads | Raise on very slow storage |
 
 **Performance Notes:**

--- a/pixelprobe/scheduler.py
+++ b/pixelprobe/scheduler.py
@@ -14,8 +14,16 @@ from sqlalchemy import text
 import threading
 import requests
 from pixelprobe.services.healthcheck_service import HealthcheckService
+from pixelprobe.utils.helpers import env_int
 
 logger = logging.getLogger(__name__)
+
+# Chunk revival: how stale a scan's heartbeat must be before its chunk workers
+# are considered provably gone (chunk tasks heartbeat every
+# CHUNK_HEARTBEAT_INTERVAL_SECS, default 120s, so 600s = 5 missed beats), and
+# how many revivals to attempt before letting the 30-minute crash branch win.
+CHUNK_REVIVE_STALENESS_SECS = env_int('CHUNK_REVIVE_STALENESS_SECS', 600, floor=120)
+_MAX_CHUNK_REVIVALS = 3
 
 
 def compute_next_interval_run(last_run, stored_next_run, unit, value, now=None):
@@ -62,6 +70,10 @@ class MediaScheduler:
 
         self.pending_retries: Dict[str, int] = {}
         self._retry_lock = threading.Lock()
+        # Per-scan count of chunk revival attempts (issue #75). In-memory is
+        # fine: a scheduler restart resets the cap, which only exists to stop
+        # an infinite revive loop from masking a permanently dead worker fleet.
+        self._revive_attempts: Dict[str, int] = {}
         # Snapshot of saved-schedule definitions; the db-sync job reloads jobs
         # only when this changes (see _sync_schedules_from_db)
         self._schedules_fp = None
@@ -857,6 +869,7 @@ class MediaScheduler:
                 ).all()
 
                 scans_to_mark = []
+                revive_threshold = current_time - timedelta(seconds=CHUNK_REVIVE_STALENESS_SECS)
                 for scan in stuck_scans:
                     # Ensure we have timezone-aware datetimes for comparison
                     # If the database stores naive datetimes, assume they're in UTC
@@ -867,6 +880,33 @@ class MediaScheduler:
                     start_time = scan.start_time
                     if start_time and start_time.tzinfo is None:
                         start_time = start_time.replace(tzinfo=timezone.utc)
+
+                    # Chunk revival (issue #75): live chunk tasks heartbeat
+                    # last_update, so a stale heartbeat with chunk rows still
+                    # active means the workers died (container restart, queue
+                    # loss) - re-dispatch the chunks instead of crashing the
+                    # scan. Discovery-phase scans are not revivable (the
+                    # orchestrator's harvest loop cannot be resumed) and fall
+                    # through to the crash branches.
+                    if (last_update and last_update < revive_threshold
+                            and scan.phase == SCAN_PHASES['SCANNING']
+                            and self._revive_attempts.get(scan.scan_id, 0) < _MAX_CHUNK_REVIVALS
+                            and ScanChunk.has_active(scan.scan_id)):
+                        try:
+                            from pixelprobe.tasks_parallel import redispatch_orphaned_chunks
+                            revived = redispatch_orphaned_chunks(
+                                scan.scan_id, force_rescan=bool(scan.force_rescan))
+                        except Exception as e:
+                            logger.error(f"Chunk revival failed for scan {scan.scan_id}: {e}")
+                            revived = 0
+                        if revived:
+                            self._revive_attempts[scan.scan_id] = \
+                                self._revive_attempts.get(scan.scan_id, 0) + 1
+                            logger.warning(
+                                f"Revived scan {scan.scan_id} "
+                                f"(attempt {self._revive_attempts[scan.scan_id]}/"
+                                f"{_MAX_CHUNK_REVIVALS}): {revived} chunks re-dispatched")
+                            continue
 
                     # Check if scan has been running for more than 30 minutes without update
                     if last_update and last_update < stuck_threshold:
@@ -894,6 +934,11 @@ class MediaScheduler:
                 if scans_to_mark:
                     db.session.commit()
                     logger.info(f"Marked {len(scans_to_mark)} stuck scans as crashed")
+
+                # Drop revival counters for scans that went terminal
+                active_ids = {s.scan_id for s in stuck_scans if s.is_active}
+                self._revive_attempts = {
+                    k: v for k, v in self._revive_attempts.items() if k in active_ids}
 
                 # Sweeper: reclaim files left in 'scanning' by a dead worker. A
                 # chunk claims files as 'scanning' before processing; if its

--- a/pixelprobe/startup.py
+++ b/pixelprobe/startup.py
@@ -51,6 +51,12 @@ def cleanup_stuck_scans(db):
     window (default 30 min, matching the periodic stuck-scan check) is treated as
     genuinely dead and crashed; anything still progressing is left alone and the
     periodic checker handles it if it later goes stale.
+
+    Deliberately does NOT re-dispatch chunk tasks here: at boot there is no way
+    to tell whether the broker retained the late-acked chunk messages (a live
+    worker may already be re-processing them). The stuck-scan sweeper revives
+    orphaned chunks instead, once heartbeat staleness proves the workers are
+    gone (see redispatch_orphaned_chunks in tasks_parallel, issue #75).
     """
     try:
         from pixelprobe.models import ScanState
@@ -68,7 +74,8 @@ def cleanup_stuck_scans(db):
                 last_activity = last_activity.replace(tzinfo=timezone.utc)
             if last_activity and last_activity > cutoff:
                 logger.info(f"Active scan {scan.id} last updated {last_activity} (within grace); "
-                            f"leaving it running across this restart")
+                            f"leaving it running across this restart - the stuck-scan "
+                            f"sweeper re-dispatches its chunks if the queue was lost")
                 continue
             logger.warning(f"Marking abandoned scan {scan.id} (last activity {last_activity}) as crashed")
             scan.is_active = False

--- a/pixelprobe/tasks_parallel.py
+++ b/pixelprobe/tasks_parallel.py
@@ -7,11 +7,21 @@ every chunk exit marks the chunk terminal and the last one finalizes the scan
 under a row lock (exactly-once). The scheduler's stuck-scan sweeper is the
 backstop if the winner dies between chunk-complete and finalize.
 Celery-free engine logic lives in pixelprobe.services.scan_engine.
+
+Liveness and recovery (issue #75): each chunk task runs a heartbeat thread
+bumping ScanState.last_update, so the sweeper's 30-minute staleness rule only
+fires on true crashes. When the heartbeat goes stale with chunk rows still
+active (dead workers, lost queue), the sweeper calls
+redispatch_orphaned_chunks to re-queue them. process_chunk_task returns
+ALREADY_TERMINAL for duplicate deliveries against a finished chunk and
+SUPERSEDED when its task id no longer matches the chunk's recorded owner.
 """
 
 import logging
 import os
+import threading
 import time
+import uuid
 from datetime import datetime, timezone
 from typing import List
 
@@ -45,6 +55,61 @@ DISCOVERY_TASK_TIMEOUT_SECS = env_int('DISCOVERY_TASK_TIMEOUT_SECS', 3600, floor
 _DISCOVERY_INSERT_BATCH = 500
 _CHUNK_COMMIT_BATCH = 100
 _PROGRESS_WRITE_INTERVAL_SECS = 60  # also write progress at least this often (stuck-sweeper safety)
+
+# Liveness heartbeat: a chunk task can sit inside checker.scan_file() for
+# 30-60+ minutes on one large movie, during which no progress write happens.
+# The heartbeat keeps ScanState.last_update moving while the task is alive so
+# the stuck-scan sweeper's 30-minute staleness rule only fires on true crashes
+# (issue #75). Daemon thread: dies with the worker, which is the point.
+_CHUNK_HEARTBEAT_INTERVAL_SECS = env_int('CHUNK_HEARTBEAT_INTERVAL_SECS', 120, floor=15)
+
+
+def _heartbeat_once(app, scan_id: str) -> bool:
+    """One liveness write on a fresh app-context session. True if a row updated.
+
+    Runs on the heartbeat thread, never on the task's session. The is_active
+    guard means a heartbeat can never resurrect a cancelled/crashed scan.
+    """
+    try:
+        with app.app_context():
+            result = db.session.execute(
+                update(ScanState)
+                .where(ScanState.scan_id == scan_id,
+                       ScanState.is_active == True)
+                .values(last_update=datetime.now(timezone.utc))
+            )
+            db.session.commit()
+            return result.rowcount > 0
+    except Exception as e:
+        logger.warning(f"Chunk heartbeat write failed for scan {scan_id}: {e}")
+        return False
+
+
+def _start_chunk_heartbeat(app, scan_id: str, chunk_db_id: int,
+                           interval: float = None) -> threading.Event:
+    """Start a daemon thread bumping ScanState.last_update; returns stop event."""
+    if interval is None:
+        interval = _CHUNK_HEARTBEAT_INTERVAL_SECS
+    stop = threading.Event()
+
+    def beat():
+        failures = 0
+        while not stop.wait(interval):
+            if _heartbeat_once(app, scan_id):
+                failures = 0
+            else:
+                failures += 1
+                if failures == 3:
+                    # Also hit when the scan was cancelled (is_active False)
+                    # and this thread has not been stopped yet - benign there
+                    logger.warning(
+                        f"Chunk {chunk_db_id} heartbeat has not updated scan "
+                        f"{scan_id} for 3 consecutive intervals")
+
+    thread = threading.Thread(target=beat, daemon=True,
+                              name=f'chunk-heartbeat:{chunk_db_id}')
+    thread.start()
+    return stop
 
 
 def _mark_chunk_terminal(chunk, status: str, files_scanned: int = None, error: str = None):
@@ -104,6 +169,7 @@ def process_chunk_task(self, chunk_db_id: int, scan_id: str, force_rescan: bool 
     and runs the finalization check."""
     logger.info(f"Worker processing chunk {chunk_db_id} for scan {scan_id}")
     first_path = last_path = None
+    hb_stop = None
 
     try:
         from flask import current_app
@@ -112,6 +178,18 @@ def process_chunk_task(self, chunk_db_id: int, scan_id: str, force_rescan: bool 
         if not chunk:
             logger.error(f"Chunk {chunk_db_id} not found")
             return {'status': 'ERROR', 'chunk_id': chunk_db_id, 'error': 'Chunk not found'}
+
+        # Duplicate-delivery guards: a ghost redelivery (broker visibility
+        # timeout) or a task superseded by chunk revival must not touch chunk
+        # state. Without the terminal guard a ghost resets a completed chunk
+        # to processing and zeroes files_scanned via the empty-claim path.
+        if chunk.is_complete:
+            logger.info(f"Chunk {chunk_db_id} already terminal, ignoring duplicate delivery")
+            return {'status': 'ALREADY_TERMINAL', 'chunk_id': chunk_db_id}
+        if chunk.celery_task_id and self.request.id and chunk.celery_task_id != self.request.id:
+            logger.info(f"Chunk {chunk_db_id} owned by task {chunk.celery_task_id}, "
+                        f"this delivery ({self.request.id}) is superseded")
+            return {'status': 'SUPERSEDED', 'chunk_id': chunk_db_id}
 
         fcp = chunk.fcp_range()
         if not fcp:
@@ -125,17 +203,32 @@ def process_chunk_task(self, chunk_db_id: int, scan_id: str, force_rescan: bool 
         chunk.start_time = datetime.now(timezone.utc)
         db.session.commit()
 
+        hb_stop = _start_chunk_heartbeat(current_app._get_current_object(),
+                                         scan_id, chunk_db_id)
+
         # Bulk claim: one statement, race-free (ranges are disjoint by construction)
-        claimed = db.session.execute(
-            update(ScanResult)
-            .where(ScanResult.file_path >= first_path,
-                   ScanResult.file_path <= last_path,
-                   ScanResult.scan_status == 'pending')
-            .values(scan_status='scanning')
-            .returning(ScanResult.id)
-        ).fetchall()
-        db.session.commit()
-        claimed_ids = [row[0] for row in claimed]
+        def claim_pending():
+            rows = db.session.execute(
+                update(ScanResult)
+                .where(ScanResult.file_path >= first_path,
+                       ScanResult.file_path <= last_path,
+                       ScanResult.scan_status == 'pending')
+                .values(scan_status='scanning')
+                .returning(ScanResult.id)
+            ).fetchall()
+            db.session.commit()
+            return [row[0] for row in rows]
+
+        claimed_ids = claim_pending()
+
+        if not claimed_ids:
+            # A worker-lost redelivery arrives with the SAME task id (acks_late
+            # + reject_on_worker_lost) while the dead attempt's rows are still
+            # claimed as 'scanning'; without this reclaim-and-retry the chunk
+            # would be marked completed with files_scanned=0 and those files
+            # silently dropped from the scan
+            _reclaim_chunk_range(first_path, last_path)
+            claimed_ids = claim_pending()
 
         if not claimed_ids:
             # Empty chunk: terminal, but never touch shared progress fields
@@ -247,12 +340,26 @@ def process_chunk_task(self, chunk_db_id: int, scan_id: str, force_rescan: bool 
             _write_chunk_progress(chunk, files_processed, scan_id, current_file)
             last_progress_write = time.time()
 
-            current_task.update_state(state='PROGRESS', meta={
-                'chunk_id': chunk_db_id,
-                'current': files_processed,
-                'total': len(claimed_ids),
-                'scan_id': scan_id,
-            })
+            # Cosmetic task metadata: a result-backend blip must not abort a
+            # chunk (real progress is already committed to the DB above)
+            try:
+                current_task.update_state(state='PROGRESS', meta={
+                    'chunk_id': chunk_db_id,
+                    'current': files_processed,
+                    'total': len(claimed_ids),
+                    'scan_id': scan_id,
+                })
+            except Exception as e:
+                logger.debug(f"Chunk {chunk_db_id} progress state update failed (non-fatal): {e}")
+
+        # Ownership re-check: if revival re-assigned this chunk while we ran
+        # (only possible after 600s of failed heartbeats), the newer task owns
+        # the terminal write and the finalize - exit without touching either
+        db.session.expire(chunk)
+        if chunk.celery_task_id and self.request.id and chunk.celery_task_id != self.request.id:
+            logger.warning(f"Chunk {chunk_db_id} was re-assigned to task "
+                           f"{chunk.celery_task_id} while this task ran; yielding")
+            return {'status': 'SUPERSEDED', 'chunk_id': chunk_db_id}
 
         _mark_chunk_terminal(chunk, 'completed', files_scanned=files_processed)
         logger.info(f"Chunk {chunk_db_id} completed: {files_processed} files, {files_corrupted} corrupted")
@@ -293,6 +400,61 @@ def process_chunk_task(self, chunk_db_id: int, scan_id: str, force_rescan: bool 
             logger.error(f"Chunk {chunk_db_id} terminal-error cleanup failed: {cleanup_error}")
             db.session.rollback()
         raise exc
+
+    finally:
+        # Stop heartbeating on every exit, including the retry path (the 60s
+        # retry countdown must not keep the old attempt's heartbeat alive)
+        if hb_stop:
+            hb_stop.set()
+
+
+def redispatch_orphaned_chunks(scan_id: str, force_rescan: bool = False) -> int:
+    """Reclaim and re-dispatch all non-terminal chunks of a scan whose workers
+    are provably gone (caller has verified last_update staleness against the
+    chunk heartbeat). Returns the number of chunks re-dispatched.
+
+    The new celery_task_id is committed BEFORE dispatch so any ghost delivery
+    of the old task returns SUPERSEDED instead of racing the revival.
+    """
+    chunks = ScanChunk.query.filter(
+        ScanChunk.scan_id == scan_id,
+        ScanChunk.status.in_(ScanChunk.ACTIVE_STATUSES)
+    ).all()
+
+    dispatched = 0
+    for chunk in chunks:
+        fcp = chunk.fcp_range()
+        if not fcp:
+            # Legacy directory-path chunks are not this engine's to re-dispatch
+            continue
+        try:
+            if chunk.status == 'processing':
+                _reclaim_chunk_range(*fcp)
+            new_id = str(uuid.uuid4())
+            chunk.status = 'pending'
+            chunk.celery_task_id = new_id
+            chunk.start_time = None
+            db.session.commit()
+            process_chunk_task.apply_async(
+                args=(chunk.id, scan_id, force_rescan), task_id=new_id)
+            dispatched += 1
+        except Exception as e:
+            # Chunk already committed as pending: the next sweep retries it;
+            # keep going so one broker hiccup does not strand the other chunks
+            logger.error(f"Failed to re-dispatch chunk {chunk.id} of scan {scan_id}: {e}")
+            db.session.rollback()
+            continue
+
+    if dispatched:
+        scan_state = ScanState.query.filter_by(scan_id=scan_id).first()
+        if scan_state:
+            scan_state.last_update = datetime.now(timezone.utc)
+            scan_state.progress_message = (
+                f'Recovered after interruption: re-dispatched {dispatched} chunks')
+            db.session.commit()
+        logger.warning(f"Revived scan {scan_id}: re-dispatched {dispatched} orphaned chunks")
+
+    return dispatched
 
 
 @celery_app.task(bind=True, soft_time_limit=DISCOVERY_TASK_TIMEOUT_SECS,
@@ -343,6 +505,12 @@ def discover_directory_task(self, directory: str, scan_id: str,
             )
             db.session.commit()
 
+    # Heartbeat: a sparse tree can walk for many minutes between flush()es
+    # (only supported files fill the batch), which would trip the 30-minute
+    # staleness rule while discovery is alive and inside its own time limit
+    from flask import current_app
+    hb_stop = _start_chunk_heartbeat(current_app._get_current_object(),
+                                     scan_id, f'discovery:{directory}')
     try:
         for root, dirs, files in os.walk(directory):
             dirs[:] = [d for d in dirs if not any(
@@ -374,6 +542,8 @@ def discover_directory_task(self, directory: str, scan_id: str,
         db.session.rollback()
         complete = False
         error = str(e)
+    finally:
+        hb_stop.set()
 
     elapsed = time.time() - start_time
     logger.info(f"Discovery of {directory}: checked {files_checked}, inserted {files_inserted} "
@@ -526,25 +696,22 @@ def parallel_scan_orchestrator(self, scan_id: str, paths: List[str] = None,
             finalize_scan(scan_state)
             return {'status': 'COMPLETED', 'scan_id': scan_id, 'total_files': 0}
 
-        job = group(
-            process_chunk_task.s(chunk['id'], scan_id, force_rescan)
-            for chunk in chunks
-        )
-        result = job.apply_async()
+        # Pre-assign task ids and commit BEFORE dispatch (cancellation support
+        # and the ownership guard in process_chunk_task): a fast worker must
+        # never observe a not-yet-written owner id, and post-dispatch writes
+        # depended on result.children order matching the signatures
+        signatures = []
+        id_mappings = []
+        for chunk in chunks:
+            task_id = str(uuid.uuid4())
+            id_mappings.append({'id': chunk['id'], 'celery_task_id': task_id})
+            signatures.append(
+                process_chunk_task.s(chunk['id'], scan_id, force_rescan)
+                .set(task_id=task_id))
+        db.session.bulk_update_mappings(ScanChunk, id_mappings)
+        db.session.commit()
 
-        # Save child task IDs for cancellation support
-        if getattr(result, 'children', None):
-            try:
-                mappings = [
-                    {'id': chunk['id'], 'celery_task_id': child.id}
-                    for chunk, child in zip(chunks, result.children)
-                    if hasattr(child, 'id')
-                ]
-                db.session.bulk_update_mappings(ScanChunk, mappings)
-                db.session.commit()
-            except Exception as e:
-                logger.error(f"Error saving chunk task IDs: {e}")
-                db.session.rollback()
+        group(signatures).apply_async()
 
         logger.info(f"Scan {scan_id}: launched {len(chunks)} chunk tasks for {total_to_scan} files")
         return {

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.7.2'
+_DEFAULT_VERSION = '2.7.3'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/static/css/desktop.css
+++ b/static/css/desktop.css
@@ -502,7 +502,7 @@ body {
 }
 
 .cancel-button {
-    background-color: var(--danger);
+    background-color: var(--danger-color);
     color: white;
     border: none;
     padding: 0.5rem 1rem;
@@ -1025,7 +1025,7 @@ input:checked + .toggle-slider:before {
 }
 
 .page-link:hover {
-    background-color: var(--bg-hover);
+    background-color: var(--bg-secondary);
     color: var(--primary-green);
     border-color: var(--primary-green);
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -675,6 +675,9 @@ class ProgressManager {
     }
 
     async startMonitoring(operationType = 'scan') {
+        // Clear any existing monitor first: switching operations (e.g. an
+        // integrity check started mid-scan) must not leak a second poll loop
+        this.stopMonitoring();
         this.operationType = operationType;
         this.show();
         
@@ -700,9 +703,12 @@ class ProgressManager {
         this.pollDelay = 1000;
         this.lastProgressValue = null;
 
+        const gen = this._monitorGen || 0;
         const pollWithBackoff = async () => {
+            if (gen !== (this._monitorGen || 0)) return; // monitor was replaced
             const previousProgress = this.lastProgressValue;
             await this.checkProgress();
+            if (gen !== (this._monitorGen || 0)) return;
 
             // If progress changed, reset to fast polling
             // Otherwise, increase delay with exponential backoff
@@ -758,6 +764,10 @@ class ProgressManager {
     }
 
     stopMonitoring() {
+        // Invalidate any in-flight poll iteration: an awaited checkProgress
+        // would otherwise reschedule itself after this clear, resurrecting a
+        // loop that no stopMonitoring() could ever reach again
+        this._monitorGen = (this._monitorGen || 0) + 1;
         if (this.checkInterval) {
             clearInterval(this.checkInterval);
             this.checkInterval = null;
@@ -1017,7 +1027,28 @@ class ProgressManager {
                 }
             }
             
-            setTimeout(() => this.hide(), 5000);
+            setTimeout(async () => {
+                // If another operation started monitoring during the 5s
+                // message window, it owns the progress view now - do not
+                // hijack it
+                if (this.checkInterval) return;
+                this.hide();
+                // A media scan may still be running (concurrent operations
+                // are allowed); resume its monitor so the UI returns to the
+                // scan progress view instead of stranding the user
+                try {
+                    const scanStatus = await this.api.getScanStatus();
+                    if (scanStatus.is_scanning) {
+                        this.startMonitoring('scan');
+                        return;
+                    }
+                } catch (error) {
+                    // Fall through and re-enable the buttons: a wrongly
+                    // enabled Start Scan is rejected server-side while a
+                    // wrongly disabled one strands the UI
+                }
+                this.updateScanButtons(false);
+            }, 5000);
         }
     }
     
@@ -2971,6 +3002,12 @@ class PixelProbeApp {
         }
         this.fileTypeCharts = {};
 
+        // Axis/grid colors come from the active theme's CSS variables so the
+        // chart stays readable in both light and dark mode
+        const styles = getComputedStyle(document.body);
+        const tickColor = styles.getPropertyValue('--text-primary').trim();
+        const gridColor = styles.getPropertyValue('--border-color').trim();
+
         // Color palette for charts - cycle through these colors for all file types
         const baseColors = [
             '#00ff88',  // Primary green
@@ -3044,23 +3081,23 @@ class PixelProbeApp {
                             type: 'logarithmic',  // Logarithmic scale for better visualization
                             beginAtZero: false,
                             ticks: {
-                                color: '#b0b0b0',
+                                color: tickColor,
                                 callback: (value) => this.formatStorage(value)
                             },
                             grid: {
-                                color: '#333'
+                                color: gridColor
                             },
                             title: {
                                 display: true,
                                 text: 'Storage (Log Scale)',
-                                color: '#b0b0b0'
+                                color: tickColor
                             }
                         },
                         y: {
                             ticks: {
-                                color: '#b0b0b0',
+                                color: tickColor,
                                 font: {
-                                    size: 10
+                                    size: 11
                                 }
                             },
                             grid: {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,22 @@ def client(app):
     """Create a test client"""
     return app.test_client()
 
+@pytest.fixture
+def tasks_parallel_mod(app):
+    """pixelprobe.tasks_parallel with the celery/app circular import satisfied.
+
+    celery_config does `from app import app` at import time; stub that module
+    with the test app so the real app.py (and its Postgres startup) never runs.
+    """
+    import sys
+    import types
+    if 'app' not in sys.modules:
+        fake = types.ModuleType('app')
+        fake.app = app
+        sys.modules['app'] = fake
+    import pixelprobe.tasks_parallel as tasks_parallel
+    return tasks_parallel
+
 @pytest.fixture(scope='function')
 def authenticated_client(app, client):
     """Create an authenticated test client with a test user"""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -608,3 +608,82 @@ class TestRetentionJob:
 
     def test_data_retention_job_registered(self, scheduler):
         assert scheduler.scheduler.get_job('data_retention_cleanup') is not None
+
+
+class TestStuckScanRevival:
+    """A scan whose chunk workers are provably gone (stale heartbeat, active
+    chunk rows) gets its chunks re-dispatched instead of being crashed;
+    after _MAX_CHUNK_REVIVALS failed revivals the crash branch fires (issue #75)."""
+
+    @pytest.fixture
+    def scheduler(self, app):
+        scheduler = MediaScheduler()
+        scheduler.init_app(app)
+        yield scheduler
+        scheduler.shutdown()
+
+    # tasks_parallel_mod fixture comes from conftest.py
+
+    def _make_scan(self, db, scan_id, minutes_stale, with_active_chunk=True):
+        from pixelprobe.models import ScanState, ScanChunk
+        scan = ScanState(
+            scan_id=scan_id, is_active=True, phase='scanning',
+            last_update=datetime.now(timezone.utc) - timedelta(minutes=minutes_stale),
+        )
+        db.session.add(scan)
+        if with_active_chunk:
+            db.session.add(ScanChunk(
+                scan_id=scan_id, chunk_id='chunk-1',
+                directory_path='/media', status='processing',
+            ))
+        db.session.commit()
+        return scan
+
+    def test_fresh_heartbeat_left_alone(self, scheduler, app, db, tasks_parallel_mod, monkeypatch):
+        from pixelprobe.models import ScanState
+        self._make_scan(db, 'rev-fresh', minutes_stale=2)
+        revive = MagicMock(return_value=2)
+        monkeypatch.setattr(tasks_parallel_mod, 'redispatch_orphaned_chunks', revive)
+        scheduler._check_stuck_scans()
+        db.session.expire_all()
+        scan = ScanState.query.filter_by(scan_id='rev-fresh').first()
+        assert scan.phase == 'scanning' and scan.is_active is True
+        revive.assert_not_called()
+
+    def test_stale_with_active_chunks_revived_not_crashed(self, scheduler, app, db,
+                                                          tasks_parallel_mod, monkeypatch):
+        from pixelprobe.models import ScanState
+        self._make_scan(db, 'rev-orphan', minutes_stale=31)
+        revive = MagicMock(return_value=2)
+        monkeypatch.setattr(tasks_parallel_mod, 'redispatch_orphaned_chunks', revive)
+        scheduler._check_stuck_scans()
+        db.session.expire_all()
+        scan = ScanState.query.filter_by(scan_id='rev-orphan').first()
+        assert scan.phase == 'scanning' and scan.is_active is True
+        revive.assert_called_once()
+        assert scheduler._revive_attempts['rev-orphan'] == 1
+
+    def test_revival_cap_exhausted_crashes(self, scheduler, app, db,
+                                           tasks_parallel_mod, monkeypatch):
+        from pixelprobe.models import ScanState
+        self._make_scan(db, 'rev-capped', minutes_stale=31)
+        revive = MagicMock(return_value=2)
+        monkeypatch.setattr(tasks_parallel_mod, 'redispatch_orphaned_chunks', revive)
+        scheduler._revive_attempts['rev-capped'] = 3
+        scheduler._check_stuck_scans()
+        db.session.expire_all()
+        scan = ScanState.query.filter_by(scan_id='rev-capped').first()
+        assert scan.phase == 'crashed' and scan.is_active is False
+        revive.assert_not_called()
+
+    def test_stale_without_chunks_crashes_unchanged(self, scheduler, app, db,
+                                                    tasks_parallel_mod, monkeypatch):
+        from pixelprobe.models import ScanState
+        self._make_scan(db, 'rev-nochunks', minutes_stale=31, with_active_chunk=False)
+        revive = MagicMock(return_value=0)
+        monkeypatch.setattr(tasks_parallel_mod, 'redispatch_orphaned_chunks', revive)
+        scheduler._check_stuck_scans()
+        db.session.expire_all()
+        scan = ScanState.query.filter_by(scan_id='rev-nochunks').first()
+        assert scan.phase == 'crashed' and scan.is_active is False
+        revive.assert_not_called()

--- a/tests/unit/test_tasks_parallel.py
+++ b/tests/unit/test_tasks_parallel.py
@@ -16,6 +16,12 @@ def engine(app):
     return engine_module
 
 
+@pytest.fixture
+def tp(tasks_parallel_mod):
+    """Shorthand for the shared tasks_parallel fixture (see conftest.py)"""
+    return tasks_parallel_mod
+
+
 def _add_pending(db, paths):
     for p in paths:
         db.session.add(ScanResult(file_path=p, scan_status='pending'))
@@ -196,3 +202,152 @@ class TestFinalization:
             assert engine.maybe_finalize_scan('scan-f6') is True
             state = ScanState.query.filter_by(scan_id='scan-f6').first()
             assert state.files_processed == 100
+
+
+class TestChunkTaskGuards:
+    """Duplicate-delivery guards: a ghost or superseded task must not touch
+    chunk state (issue #75)"""
+
+    def test_terminal_chunk_returns_already_terminal(self, tp, app, db):
+        with app.app_context():
+            _make_scan_state(db, 'scan-g1')
+            chunk = _make_chunk(db, 'scan-g1', '/a', '/b', is_complete=True,
+                                status='completed', files_scanned=42)
+            result = tp.process_chunk_task.apply(args=(chunk.id, 'scan-g1')).get()
+            assert result['status'] == 'ALREADY_TERMINAL'
+            chunk = db.session.get(ScanChunk, chunk.id)
+            assert chunk.status == 'completed'
+            assert chunk.files_scanned == 42
+
+    def test_superseded_task_id_claims_nothing(self, tp, app, db):
+        with app.app_context():
+            _add_pending(db, ['/a/f1.mkv'])
+            _make_scan_state(db, 'scan-g2')
+            chunk = _make_chunk(db, 'scan-g2', '/a', '/b', status='pending')
+            chunk.celery_task_id = 'the-current-owner'
+            db.session.commit()
+            # apply() runs with a generated eager task id != the-current-owner
+            result = tp.process_chunk_task.apply(args=(chunk.id, 'scan-g2')).get()
+            assert result['status'] == 'SUPERSEDED'
+            assert ScanResult.query.filter_by(scan_status='scanning').count() == 0
+            chunk = db.session.get(ScanChunk, chunk.id)
+            assert chunk.status == 'pending'
+
+
+class TestChunkHeartbeat:
+    """Heartbeat makes ScanState.last_update a liveness signal (issue #75)"""
+
+    def test_heartbeat_once_bumps_active_scan(self, tp, app, db):
+        with app.app_context():
+            state = _make_scan_state(db, 'scan-h1')
+            old = datetime(2020, 1, 1, tzinfo=timezone.utc)
+            state.last_update = old
+            db.session.commit()
+        assert tp._heartbeat_once(app, 'scan-h1') is True
+        with app.app_context():
+            state = ScanState.query.filter_by(scan_id='scan-h1').first()
+            assert state.last_update is not None
+            lu = state.last_update
+            if lu.tzinfo is None:
+                lu = lu.replace(tzinfo=timezone.utc)
+            assert lu > old
+
+    def test_heartbeat_skips_inactive_scan(self, tp, app, db):
+        with app.app_context():
+            state = _make_scan_state(db, 'scan-h2', is_active=False)
+            state.last_update = datetime(2020, 1, 1, tzinfo=timezone.utc)
+            db.session.commit()
+        assert tp._heartbeat_once(app, 'scan-h2') is False
+
+    def test_heartbeat_swallows_db_errors(self, tp, app):
+        with patch.object(tp.db, 'session') as mock_session:
+            mock_session.execute.side_effect = RuntimeError('pool exhausted')
+            assert tp._heartbeat_once(app, 'scan-h3') is False
+
+    def test_heartbeat_thread_lifecycle(self, tp, app):
+        import time as _time
+        with patch.object(tp, '_heartbeat_once') as mock_beat:
+            stop = tp._start_chunk_heartbeat(app, 'scan-h4', 1, interval=0.02)
+            deadline = _time.time() + 2
+            while mock_beat.call_count < 2 and _time.time() < deadline:
+                _time.sleep(0.01)
+            stop.set()
+            assert mock_beat.call_count >= 2
+
+
+class TestRedispatchOrphanedChunks:
+    """Revival of chunks whose workers are provably gone (issue #75)"""
+
+    def _setup_orphaned_scan(self, db):
+        _add_pending(db, ['/a/f1.mkv', '/a/f2.mkv'])
+        state = _make_scan_state(db, 'scan-r1')
+        state.force_rescan = False
+        processing = _make_chunk(db, 'scan-r1', '/a/f1.mkv', '/a/f1.mkv',
+                                 status='processing')
+        # simulate the dead worker's claimed row
+        row = ScanResult.query.filter_by(file_path='/a/f1.mkv').first()
+        row.scan_status = 'scanning'
+        pending = _make_chunk(db, 'scan-r1', '/a/f2.mkv', '/a/f2.mkv',
+                              status='pending')
+        done = _make_chunk(db, 'scan-r1', '/z', '/z2', is_complete=True,
+                           status='completed', files_scanned=7)
+        db.session.commit()
+        return processing, pending, done
+
+    def test_reclaims_and_redispatches_nonterminal_chunks(self, tp, app, db):
+        with app.app_context():
+            processing, pending, done = self._setup_orphaned_scan(db)
+            with patch.object(tp.process_chunk_task, 'apply_async') as mock_async:
+                count = tp.redispatch_orphaned_chunks('scan-r1')
+            assert count == 2
+            assert mock_async.call_count == 2
+            row = ScanResult.query.filter_by(file_path='/a/f1.mkv').first()
+            assert row.scan_status == 'pending'
+            for chunk in (db.session.get(ScanChunk, processing.id),
+                          db.session.get(ScanChunk, pending.id)):
+                assert chunk.status == 'pending'
+                assert chunk.celery_task_id
+                assert chunk.start_time is None
+            # dispatched task_id matches the stored ownership id
+            dispatched_ids = {c.kwargs['task_id'] for c in mock_async.call_args_list}
+            stored_ids = {db.session.get(ScanChunk, processing.id).celery_task_id,
+                          db.session.get(ScanChunk, pending.id).celery_task_id}
+            assert dispatched_ids == stored_ids
+            done_chunk = db.session.get(ScanChunk, done.id)
+            assert done_chunk.status == 'completed'
+            assert done_chunk.files_scanned == 7
+            state = ScanState.query.filter_by(scan_id='scan-r1').first()
+            assert 'Recovered' in (state.progress_message or '')
+
+    def test_dispatch_error_attempts_every_chunk(self, tp, app, db):
+        with app.app_context():
+            self._setup_orphaned_scan(db)
+            with patch.object(tp.process_chunk_task, 'apply_async',
+                              side_effect=RuntimeError('broker down')) as mock_async:
+                count = tp.redispatch_orphaned_chunks('scan-r1')
+            # One broker hiccup must not strand the remaining chunks
+            assert count == 0
+            assert mock_async.call_count == 2
+
+
+class TestWorkerLostRedelivery:
+    """acks_late + reject_on_worker_lost redelivers the SAME task id after a
+    worker dies mid-chunk; the leftover 'scanning' rows must be reclaimed and
+    re-scanned, not dropped via the empty-claim completed-with-0 path"""
+
+    def test_redelivery_reclaims_scanning_rows(self, tp, app, db):
+        with app.app_context():
+            _add_pending(db, ['/nonexistent/f1.mkv'])
+            row = ScanResult.query.filter_by(file_path='/nonexistent/f1.mkv').first()
+            row.scan_status = 'scanning'  # claimed by the dead attempt
+            _make_scan_state(db, 'scan-wl1')
+            chunk = _make_chunk(db, 'scan-wl1', '/nonexistent/f1.mkv',
+                                '/nonexistent/f1.mkv', status='processing')
+            db.session.commit()
+
+            result = tp.process_chunk_task.apply(args=(chunk.id, 'scan-wl1')).get()
+
+            assert result['status'] == 'SUCCESS'
+            assert result['files_processed'] == 1
+            row = ScanResult.query.filter_by(file_path='/nonexistent/f1.mkv').first()
+            assert row.scan_status != 'scanning'


### PR DESCRIPTION
## Summary

Fixes #74 and #75.

### Scan falsely marked crashed, and no recovery after restarts (#75)

The reporter's log showed the stuck-scan check firing its 30-minute no-progress rule while chunk workers were healthy - they were just inside hour-long ffmpeg validations of big movies, and progress was only written when a file finished. Container restarts made it worse: the queued chunk tasks were lost, startup kept the scan alive "within grace", and nothing ever re-queued the work, so the scan sat idle until the same rule crashed it.

- Each chunk task now runs a heartbeat thread bumping the scan's `last_update` every `CHUNK_HEARTBEAT_INTERVAL_SECS` (default 120s). Staleness now genuinely means dead workers, so the 30-minute rule is unchanged and correct. Discovery walks heartbeat too - a sparse tree could previously go 30+ minutes between batch flushes and get falsely crashed.
- The stuck-scan sweeper revives orphaned chunks: when the heartbeat is stale but chunk rows are still active, it reclaims the dead workers' claimed files and re-dispatches the chunks (up to 3 attempts, threshold `CHUNK_REVIVE_STALENESS_SECS`, default 600s; after that the crash branch wins as before).
- Ownership hardening that fell out of review: chunk task ids are assigned and committed before dispatch (previously written afterwards from the group result); a task whose chunk is finished or owned by a newer id exits without touching state; and a worker-lost redelivery now reclaims the dead attempt's claimed files instead of marking the chunk complete with zero files - a pre-existing path that silently dropped files from a scan.

Known limitation: liveness is scan-level, so if some workers die while one chunk keeps running, revival of the dead chunks waits until the survivor finishes and the heartbeat goes stale. Chunk-level liveness would need a schema change; not worth it yet.

### Light-mode and progress-view fixes (#74)

- The cancel button styled itself with `var(--danger)`, which was never defined - transparent background, white text, invisible on a light page. Fixed to `--danger-color`; the pagination hover had the same undefined-variable defect.
- The "Files by type" chart hardcoded dark-theme axis/grid colors. It now reads the active theme's CSS variables at render time, and the file-type labels went from 10px to 11px.
- Starting an integrity check during a running scan no longer strands the UI: on completion it returns to the scan's progress view (or re-enables the scan buttons if the scan finished meanwhile). Monitor handoffs got a generation token so an in-flight poll iteration can't resurrect a stopped loop, and a stale completion timer can't hijack a newly started operation. Clickable-cards-style blocking was deliberately not added - concurrent integrity checks are supported and now behave.

## Version

2.7.3

## Test plan

- [x] 14 new tests: heartbeat write/lifecycle, duplicate-delivery guards, worker-lost redelivery reclaim, orphan revival, scheduler revive-vs-crash branches
- [x] Full suite: 500 passed, 8 skipped (real-media tests run in CI's in-image job)
- [x] Webpack production build clean
- [ ] CI and CodeQL green
- [ ] Docker image built, scanned, pushed