### PR TITLE
Corroborate freezes against the file, scope mark-as-good to its finding (v2.8.8)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [2.8.8] - 2026-08-26
+
+### Changed
+
+- **A frozen picture is now judged by why it stopped, not how it looks.** freezedetect finds where the picture stops changing, but a held animation drawing and a static title card stop the picture too, and no threshold separates them from damage: across 34 verified warnings, real findings started at 7 seconds while false positives reached 41. Each candidate is now corroborated against the file itself. A packet probe (a handful of seeks, no decode) asks whether the stream even has data where the clock kept running; a window decode asks whether the decoder can produce frames there. Absent packets become a **Missing content** corruption verdict, a flood of decoder errors becomes a **Decode failure** corruption verdict, and a freeze with neither signal stopped on purpose and is discounted. A single uncorroborated event past `detection.freeze_uncorroborated_min_secs` (default 60 seconds) still warns, so a source that recorded a genuinely stuck picture is not silent. In the verified sample this classifies all 34 correctly: 26 cels and cards discounted, 6 missing-content and 2 decode-failure files promoted from warnings to the corruption verdicts they deserved.
+- **Mark-as-good is now a judgement about a finding, not a permanent mute on a file.** Marking a file good records the file hash and the class of finding excused. On rescan the override lapses if the content changed (this is not the file that was reviewed) or if a different class of finding appears (excusing a freeze warning must not hide a later incomplete-file verdict). The date and excused class stay recorded after it lapses, following the bitrot flag's keep-history pattern. Existing marked files are backfilled once at startup, treating the upgrade as the review moment, and rows with no recorded details keep their old excuse-everything behaviour.
+
+### Removed
+
+- The static-card and freeze-confirmation filters and their six tunables (`static_card_edge_secs`, `static_card_max_secs`, `freeze_confirm_noise`, `freeze_confirm_max_windows`, `freeze_confirm_budget_secs`, `freeze_confirm_timeout_secs`). Corroboration subsumes both: a card and a cel are simply uncorroborated. This also removes one ffmpeg process per confirmed candidate; corroboration probes only events on files that already flagged, and the packet probe costs a fraction of a second. Stored values for the removed settings are ignored. The black-frame filter stays, since a long fade to black is uncorroborated but should not warn.
+
+### Fixed
+
+- **Review findings on the new code, before release.** The finding classifier now splits the stored '; '-joined details so an unrecognised finding cannot hide behind a recognised neighbour, and its markers match the strings the scanner actually emits. The excused-verdict column is wide enough for every reachable class combination, and the migration commits the new columns before backfilling so a bad legacy row cannot roll the schema back. Override retirement runs in the single-file rescan path as well as chunked scans. Marking a healthy file stores a sentinel that excuses nothing rather than the excuse-everything NULL. Missing-content corroboration requires a steady packet cadence around the window, so a variable-frame-rate source that legitimately stores nothing while the picture holds cannot be called corrupt, and expected packets come from the file's declared average rate. The backfill timestamp is UTC regardless of the database server's timezone.
+
+### Tests
+
+- 9 corroboration tests (discount, end-card shape without a special rule, absent packets, decoder errors, variable-rate stillness never corrupting, long uncorroborated warning, threshold as a setting, probe failure never promoting to corruption, per-file cap) and 15 override-scoping tests (classification, lapse on content change, lapse on class change, legacy NULL behaviour, recording at mark time).
+- The percentage-clamp test moved to events inside the container, because an event outrunning the container now correctly corroborates as missing content, which gets its own test.
+
 ## [2.8.7] - 2026-08-23
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -757,9 +757,7 @@ What counts as a finding. These decide which files get flagged.
 |---------|----------------|---------|--------------|
 | `detection.freeze_detection_enabled` | Detect frozen video | `on` | Look for stretches where the picture stops changing. This is a full decode of every video and is the slowest part of a scan. |
 | `detection.freeze_min_duration_secs` | Shortest freeze to report | `7.0` seconds | Seconds. Animation holds a drawing still for several seconds at a time, so a low value reports ordinary cartoons. Raise it to report only longer freezes. Range 1.0 to 600.0. |
-| `detection.static_card_edge_secs` | Title and end card window | `60.0` seconds | Seconds from either end of a file. A single short freeze inside this window is a motionless title or end card and is not reported. Set to 0 to report them. Range 0.0 to 600.0. |
-| `detection.static_card_max_secs` | Longest title or end card | `15.0` seconds | Seconds. A freeze longer than this is reported even when it sits at the very start or end of a file. Range 0.0 to 600.0. |
-| `detection.freeze_confirm_noise` | Freeze confirmation tolerance | `0.0001` | How different two frames may be and still count as identical, from 0 to 1. Every candidate is re-checked at this tolerance, which separates a stuck picture from a shot that is merely very still. Range 0.0 to 1.0. |
+| `detection.freeze_uncorroborated_min_secs` | Longest freeze to excuse | `60.0` seconds | Seconds. A frozen stretch with its packets present and its frames decodable stopped on purpose, so it is not reported. Past this length it is reported anyway, in case a source recorded a genuinely stuck picture. Range 10.0 to 3600.0. |
 | `detection.data_hole_alloc_ratio` | Incomplete file check threshold | `0.9` | A file storing less data than its length claims is opened and checked for unwritten regions. Compressing filesystems store healthy files in less space, so this only decides which files are worth checking. Range 0.0 to 1.0. |
 | `detection.data_hole_min_pct` | Unwritten share that means damage | `1.0` percent | Percent of a file that must be unwritten before it is called incomplete. Range 0.0 to 100.0. |
 
@@ -769,8 +767,6 @@ Limits on how much work one file may cost. These bound scan time, not accuracy.
 
 | Setting | Name in the UI | Default | What it does |
 |---------|----------------|---------|--------------|
-| `performance.freeze_confirm_max_windows` | Freeze checks per file | `20` | Each check is its own decode. Past this count the remaining freezes are reported without being confirmed rather than dropped. Range 1 to 500. |
-| `performance.freeze_confirm_budget_secs` | Time budget for freeze checks | `600` seconds | Seconds one file may spend confirming freezes. Once spent, the rest are reported without being confirmed. Range 30 to 7200. |
 | `performance.temporal_sample_secs` | Length of each sampled window | `10` seconds | Seconds decoded at each of three points in a large file when looking for timing anomalies. Range 5 to 120. |
 | `performance.temporal_min_frames` | Frames needed to judge a window | `100` | Below this many decoded frames the measurements are noise and no verdict is recorded. Range 1 to 10000. |
 
@@ -780,7 +776,6 @@ How long to wait on storage and tools before giving up on a file.
 
 | Setting | Name in the UI | Default | What it does |
 |---------|----------------|---------|--------------|
-| `timeouts.freeze_confirm_timeout_secs` | Single freeze check timeout | `300` seconds | Seconds to wait on one freeze confirmation before keeping the freeze unchecked. Range 30 to 7200. |
 | `timeouts.temporal_sample_timeout_secs` | Sampled window timeout | `30` seconds | Seconds to wait on one sampled window. Raise this on a busy host, where a timeout means contention rather than a bad file. Range 10 to 3600. |
 | `timeouts.ffprobe_timeout_secs` | Metadata read timeout | `120` seconds | Seconds to wait when reading a file's metadata. Raise it on slow storage. Range 10 to 3600. |
 | `timeouts.file_read_timeout_secs` | File read timeout | `60` seconds | Seconds to wait on a raw read before treating the file as unreadable and moving on. The hashing deadline scales up with file size on top of this. Range 10 to 3600. |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,7 +20,7 @@ Every term PixelProbe uses, defined once and linked to the doc that covers it.
 - **Healthy** - The file decoded and validated without corruption signals. Benign decoder noise (NAL unit warnings, DTS/PTS timestamp warnings, ffmpeg 8 Opus EOF parse notices) does not affect this verdict.
 - **Corrupted** - A corruption signal with a verdict fired: an incomplete file, FFmpeg validation failure, JPEG pixel corruption, or a decode error flood. See [Scan Types](scan-types.md).
 - **Warning** - A signal that is informative but does not prove damage: confirmed freeze events, frame-count mismatches, elevated TOUT or VREP, strict-decode notices, tool resource limits on oversized images. Warning files play back fine in most cases. See [Scan Types](scan-types.md).
-- **Marked as good** - A manual override: the file keeps its scan history but is treated as healthy in stats and filters.
+- **Marked as good** - A manual override scoped to what was reviewed: it records the file's hash and the class of finding it excused. It lapses on rescan if the content changed or a different class of finding appears, so excusing a freeze warning cannot hide a later incomplete-file verdict. The date and excused class stay recorded after it lapses.
 - **Error** - The file could not be read or scanned at all (permissions, I/O failure, unreadable media).
 
 ## Deep checks
@@ -34,9 +34,9 @@ Every term PixelProbe uses, defined once and linked to the doc that covers it.
 - **Strict error detection (Stage 4)** - A decode pass with aggressive error flags. Warning-only.
 - **Data integrity check** - A `SEEK_HOLE` query, run before any decode on files whose allocated blocks fall short of their length, that finds files allocated at full size but never fully written. Reads no file data. Marks the file corrupted. See [Scan Types](scan-types.md).
 - **Incomplete file** - A file whose length is correct but whose contents have gaps: an interrupted download or copy left regions the filesystem never allocated. Demuxers skip past them, so the picture holds while the clock keeps running. Reported as corruption, not as a freeze.
-- **Freeze detection** - A full-decode pass with FFmpeg's `freezedetect` filter that reports stretches where the picture stops changing; black frames, static cards, and unconfirmed near-static segments are filtered as false positives. Warning-only. Switched on and off, and its shortest reported freeze set, under Tunables. See [Configuration](configuration.md#scanner-settings).
-- **Static card** - A motionless title or end plate (distributor logo, copyright notice, sponsor credit). The picture really does stop, so the detector is correct and only the verdict would be wrong. A solitary short freeze against either end of a file is discounted rather than reported.
-- **Freeze confirmation pass** - A re-check of each surviving candidate at a noise tolerance only repeated frames can clear. Limited animation holds its background and moves a few small figures, which scores below the default whole-frame tolerance; the confirmation pass separates a genuinely stuck picture from a held cel.
+- **Freeze detection** - A full-decode pass with FFmpeg's `freezedetect` filter that reports stretches where the picture stops changing; candidates are corroborated against the file, so absent packets or a failing decoder become corruption verdicts while intentional stillness is discounted. Switched on and off, and its shortest reported freeze set, under Tunables. See [Configuration](configuration.md#scanner-settings).
+- **Freeze corroboration** - The check that decides whether a frozen picture is damage. A packet probe asks whether the stream even has data where the clock kept running; a window decode asks whether the decoder can produce frames there. Absent packets or failing decode make the freeze a corruption verdict; neither signal means the picture stopped on purpose (a title card, an end plate, a held animation drawing) and the event is discounted.
+- **Uncorroborated minimum** - The length past which a freeze is reported even though the file shows nothing wrong, so a source that recorded a genuinely stuck picture is not silent. A tunable, default 60 seconds.
 
 ## Settings
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -441,12 +441,13 @@ Each file is validated in `pixelprobe/media_checker.py` (`PixelProbe.scan_file`)
      - **Stage 3 - Multi-point sampling** (files > 5GB): decodes 10s samples at beginning, middle, and end; NEVER marks a file corrupted (seeking produces FFmpeg-version-dependent false positives), results are informational
      - **Stage 4 - Strict error detection** (warnings only): `-err_detect crccheck+bitstream+buffer+explode` over the first 30 seconds; findings are container/muxing warnings, never corruption verdicts
 
-6. **Freeze detection** (videos, separate pass): a full-decode pass through FFmpeg's `freezedetect` filter (with `blackdetect`) flags frozen-picture segments, then three filters run over the candidates:
-   - Segments overlapping a black section are dropped, because a real freeze sticks on picture rather than on a fade
-   - A solitary short freeze against either end of the file is discounted as a static title or end card. The bound is the smaller of 60 seconds and 10% of runtime, so on a short clip it cannot reach the middle of the file
-   - Each surviving candidate is re-checked over its own window at a noise tolerance only repeated frames can clear. The default tolerance compares a whole-frame mean, which limited animation scores below while every frame still differs; the confirmation pass drops those. If the pass cannot run, the candidate is kept, so a failure never erases a finding
+6. **Freeze detection** (videos, separate pass): a full-decode pass through FFmpeg's `freezedetect` filter (with `blackdetect`) finds stretches where the picture stops changing. Finding a freeze is not the verdict, because a held animation cel and a static title card also stop the picture. Each candidate is corroborated against the file itself:
+   - Segments overlapping a black section are dropped first, because a real freeze sticks on picture rather than on a fade
+   - A packet probe over the window (a handful of seeks, no decode): if the stream barely has packets where the clock kept running, the segment is **missing content** and the file is marked corrupted
+   - A decode of just the window: a flood of decoder errors means the picture held because no frames could be produced, which is a **decode failure** and also corruption
+   - A freeze with neither signal stopped on purpose and is discounted, with the reason in the transcript. The exception is a single event running past the uncorroborated minimum (default 60 seconds), which stays a warning so a source that recorded a genuinely stuck picture is not silent
 
-   What survives is a warning - it never marks a file corrupted - and the whole pass can be switched off under System > Tunables. Reported frozen time counts overlapping events once and is capped at the runtime.
+   Reported frozen time counts overlapping events once and is capped at the runtime. The whole pass can be switched off under System > Tunables.
 
 7. **Dynamic timeouts**: FFmpeg validation timeouts are computed from file size and duration (roughly 3 minutes per GB or ~2x realtime, capped at 2 hours), so large files are neither killed prematurely nor allowed to hang forever.
 

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -8,7 +8,7 @@
 - `BATCH_SIZE=100` - Paths per database lookup batch during file discovery (default: 100). Leave at 100; it does not control scan chunk size, which is automatic (see the chunk table below).
 - Freeze detection, its confirmation limits, and the scan timeouts are settings rather than environment variables. Edit them under System > Tunables or through `/api/settings`; a change reaches a running scan without a restart. See [Configuration](configuration.md#scanner-settings).
 - The data integrity check is close to free. The allocation gate reuses the block count from the `stat` the scanner already performs, and files that fail it are queried with `SEEK_HOLE`, which reads no file data. A file it marks incomplete skips decoding entirely, which on a large damaged file saves a full-length pass.
-- The freeze confirmation pass runs only on files that already produced a candidate, and only over that candidate's own window. Each window is its own ffmpeg process, bounded two ways: a cap on how many run (default 20) and a wall-time budget per file (default 600s). Events past either bound are reported without confirmation rather than dropped.
+- Freeze corroboration runs only on files that already produced a candidate. Each event costs one packet probe (a fraction of a second, no decode) and, when the packets are present, one decode of just that window. At most 12 events per file are probed; the rest fall through to the uncorroborated path.
 - `time_budget_minutes` - Per-schedule setting on file-changes schedules. Caps how long a rolling integrity check runs; the next run resumes where the last one stopped.
 
 ### Database performance

--- a/docs/scan-types.md
+++ b/docs/scan-types.md
@@ -256,6 +256,8 @@ Something failed that proves damage. The reason is recorded in the file's corrup
 | Reason | What it means |
 |---|---|
 | Incomplete file | The file is the right length but parts of it were never written. An interrupted download or copy. The missing share is reported in the detail line |
+| Missing content | A frozen stretch whose packets are absent from the stream. The clock kept running but nothing was stored for it |
+| Decode failure | A frozen stretch where the decoder could not produce frames, with the error count in the detail line |
 | FFmpeg validation failure | A full remux pass could not read the container or its streams |
 | Decode error flood | Enough decode errors to rule out ordinary noise |
 | JPEG pixel corruption | Pixel-level damage found by the JPEG analyzer |
@@ -266,7 +268,7 @@ A signal worth surfacing that does not prove damage. These files usually play fi
 
 | Reason | What it means |
 |---|---|
-| Freeze events | The picture stops changing for a stretch, confirmed as genuinely repeated frames |
+| Freeze events | The picture stops changing for longer than the uncorroborated minimum, with nothing else wrong in the file |
 | Frame-count mismatch | Counted packets disagree with what duration and frame rate predict. Container metadata is unreliable on sparse-video and variable-frame-rate files |
 | Elevated TOUT or VREP | Temporal outliers or vertical line repetition. Film grain raises the first; flat graphic content raises the second |
 | Strict-decode notices | Findings from an aggressive error-detection pass, usually container or muxing quirks |
@@ -285,8 +287,7 @@ These are real observations, not defects. PixelProbe discounts them and records 
 | Finding | Why it is discounted |
 |---|---|
 | Freeze over a black section | Fades and transitions hold black. A real freeze sticks on picture |
-| Static title or end card | Distributor logos, copyright plates, and sponsor credits are motionless by design. A solitary short freeze against either end of a file is a card |
-| Near-static segment | Limited animation holds its background and moves a few small figures, which scores below the detector's whole-frame tolerance even though every frame differs. A confirmation pass separates these from a stuck picture |
+| Uncorroborated freeze | The picture stopped, the packets are present, and the frames decode. Title cards, end plates and held animation drawings all look like this, and so does any deliberate stillness. Only a stretch past the uncorroborated minimum is reported |
 | Under-allocation without gaps | Filesystems with compression or dedup store a healthy file in fewer blocks than its size. Only genuinely unallocated regions produce a verdict, so written zero bytes such as digital silence never count |
 
 ## API response examples

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -231,6 +231,15 @@ components:
         marked_as_good:
           type: boolean
           description: User-marked as not corrupted (false positive)
+        marked_good_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the mark-as-good judgement was made
+        marked_good_verdict:
+          type: string
+          nullable: true
+          description: Comma-joined finding classes the mark excused; the override lapses if the content changes or a different class appears
         has_warnings:
           type: boolean
           description: Whether scan produced warnings

--- a/pixelprobe/api/admin_routes.py
+++ b/pixelprobe/api/admin_routes.py
@@ -12,6 +12,7 @@ from pixelprobe.services.settings_service import (describe_settings, coerce_sett
                                                   invalidate_cache, plain_bound,
                                                   SettingValueError)
 from pixelprobe.scheduler import MediaScheduler
+from pixelprobe.utils.overrides import classify_findings, encode_verdict
 from pixelprobe.utils.security import validate_json_input, AuditLogger, validate_directory_path
 from pixelprobe.utils.validators import validate_time_budget
 from pixelprobe.utils.integrity import adopt_bitrot_baseline
@@ -115,6 +116,16 @@ def mark_as_good():
             if result:
                 result.marked_as_good = True
                 result.is_corrupted = False
+                # Record what this judgement actually excused: this file
+                # version, these finding classes. The scan write path retires
+                # the override when either stops matching.
+                result.marked_good_hash = result.file_hash
+                result.marked_good_date = datetime.now(timezone.utc)
+                # A mark on a file with no findings excuses nothing: store a
+                # sentinel rather than NULL, because NULL means excuse-everything
+                # and is reserved for legacy rows whose reason is unknown.
+                result.marked_good_verdict = encode_verdict(
+                    classify_findings(result.corruption_details, result.warning_details)) or 'none'
                 logger.info(f"Marked file as good (healthy): {result.file_path}")
                 AuditLogger.log_action('mark_as_good', {'file_id': file_id, 'file_path': result.file_path})
             

--- a/pixelprobe/constants.py
+++ b/pixelprobe/constants.py
@@ -167,43 +167,17 @@ SCANNER_SETTINGS = [
         'unit': 'seconds',
     },
     {
-        'key': 'detection.static_card_edge_secs',
+        'key': 'detection.freeze_uncorroborated_min_secs',
         'group': SETTING_GROUP_DETECTION,
-        'label': 'Title and end card window',
-        'help': 'Seconds from either end of a file. A single short freeze inside this window is a '
-                'motionless title or end card and is not reported. Set to 0 to report them.',
+        'label': 'Longest freeze to excuse',
+        'help': 'Seconds. A frozen stretch with its packets present and its frames decodable '
+                'stopped on purpose, so it is not reported. Past this length it is reported '
+                'anyway, in case a source recorded a genuinely stuck picture.',
         'type': 'float',
         'default': 60.0,
-        'min': 0.0,
-        'max': 600.0,
+        'min': 10.0,
+        'max': 3600.0,
         'unit': 'seconds',
-        'legacy_env': 'STATIC_CARD_EDGE_SECS',
-    },
-    {
-        'key': 'detection.static_card_max_secs',
-        'group': SETTING_GROUP_DETECTION,
-        'label': 'Longest title or end card',
-        'help': 'Seconds. A freeze longer than this is reported even when it sits at the very '
-                'start or end of a file.',
-        'type': 'float',
-        'default': 15.0,
-        'min': 0.0,
-        'max': 600.0,
-        'unit': 'seconds',
-        'legacy_env': 'STATIC_CARD_MAX_SECS',
-    },
-    {
-        'key': 'detection.freeze_confirm_noise',
-        'group': SETTING_GROUP_DETECTION,
-        'label': 'Freeze confirmation tolerance',
-        'help': 'How different two frames may be and still count as identical, from 0 to 1. Every '
-                'candidate is re-checked at this tolerance, which separates a stuck picture from '
-                'a shot that is merely very still.',
-        'type': 'float',
-        'default': 0.0001,
-        'min': 0.0,
-        'max': 1.0,
-        'legacy_env': 'FREEZE_CONFIRM_NOISE',
     },
     {
         'key': 'detection.data_hole_alloc_ratio',
@@ -231,31 +205,6 @@ SCANNER_SETTINGS = [
         'legacy_env': 'DATA_HOLE_MIN_PCT',
     },
     {
-        'key': 'performance.freeze_confirm_max_windows',
-        'group': SETTING_GROUP_PERFORMANCE,
-        'label': 'Freeze checks per file',
-        'help': 'Each check is its own decode. Past this count the remaining freezes are reported '
-                'without being confirmed rather than dropped.',
-        'type': 'int',
-        'default': 20,
-        'min': 1,
-        'max': 500,
-        'legacy_env': 'FREEZE_CONFIRM_MAX_WINDOWS',
-    },
-    {
-        'key': 'performance.freeze_confirm_budget_secs',
-        'group': SETTING_GROUP_PERFORMANCE,
-        'label': 'Time budget for freeze checks',
-        'help': 'Seconds one file may spend confirming freezes. Once spent, the rest are reported '
-                'without being confirmed.',
-        'type': 'int',
-        'default': 600,
-        'min': 30,
-        'max': 7200,
-        'unit': 'seconds',
-        'legacy_env': 'FREEZE_CONFIRM_BUDGET_SECS',
-    },
-    {
         'key': 'performance.temporal_sample_secs',
         'group': SETTING_GROUP_PERFORMANCE,
         'label': 'Length of each sampled window',
@@ -279,18 +228,6 @@ SCANNER_SETTINGS = [
         'min': 1,
         'max': 10000,
         'legacy_env': 'TEMPORAL_MIN_FRAMES',
-    },
-    {
-        'key': 'timeouts.freeze_confirm_timeout_secs',
-        'group': SETTING_GROUP_TIMEOUTS,
-        'label': 'Single freeze check timeout',
-        'help': 'Seconds to wait on one freeze confirmation before keeping the freeze unchecked.',
-        'type': 'int',
-        'default': 300,
-        'min': 30,
-        'max': 7200,
-        'unit': 'seconds',
-        'legacy_env': 'FREEZE_CONFIRM_TIMEOUT_SECS',
     },
     {
         'key': 'timeouts.temporal_sample_timeout_secs',

--- a/pixelprobe/media_checker.py
+++ b/pixelprobe/media_checker.py
@@ -29,6 +29,7 @@ from pixelprobe.utils.helpers import env_int, env_float
 from pixelprobe.utils.integrity import apply_scan_baseline
 from pixelprobe.utils.paths import is_path_under
 from pixelprobe.services.settings_service import resolve_settings
+from pixelprobe.utils.overrides import retire_stale_override
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +151,40 @@ _RE_FREEZE_START = re.compile(r'freeze_start:\s*([\d.]+)')
 _RE_FREEZE_END = re.compile(r'freeze_end:\s*([\d.]+)')
 _RE_FREEZE_DURATION = re.compile(r'freeze_duration:\s*([\d.]+)')
 
+def _steady_cadence(pts, spread=2.0, minimum=8):
+    """Whether timestamps tick at a steady rhythm.
+
+    True when the large gaps between consecutive packets stay within `spread`
+    times the median gap. Constant-frame-rate video is steady; variable-rate
+    sources (screen recordings, slideshows) are not, and an absent stretch in
+    an unsteady stream proves nothing.
+    """
+    if len(pts) < minimum:
+        return False
+    gaps = sorted(b - a for a, b in zip(pts, pts[1:]) if b > a)
+    if not gaps:
+        return False
+    median = gaps[len(gaps) // 2]
+    high = gaps[int(len(gaps) * 0.95)] if len(gaps) > 1 else median
+    return median > 0 and high <= median * spread
+
+
+def _parse_rate(text):
+    """Parse an ffprobe rate fraction like '24000/1001'. None when unusable
+    (missing, zero, or the '0/0' ffprobe emits for unknown rates)."""
+    if not text:
+        return None
+    try:
+        if '/' in str(text):
+            num, den = str(text).split('/', 1)
+            value = float(num) / float(den)
+        else:
+            value = float(text)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+    return value if value > 0 else None
+
+
 def _parse_freeze_events(lines):
     """Parse freezedetect events out of pre-split FFmpeg stderr lines.
 
@@ -199,54 +234,19 @@ def _merged_frozen_seconds(events):
     return total
 
 
-def _drop_static_cards(freeze_events, duration):
-    """Separate static title and end cards from freeze events worth reporting.
+# Corroboration asks what else is true where the picture stopped: are the
+# packets even there, and can the decoder produce pictures? A freeze with
+# neither signal is a held animation cel or a static title/end card, not
+# damage. Thresholds are generous because observed real cases are extreme
+# (87-100% of packets absent; thousands of decode errors in one window).
+FREEZE_PACKET_ABSENT_RATIO = 0.2  # under this fraction of expected packets = missing content
+FREEZE_DECODE_ERROR_MIN = 20      # more error lines than this in one window = decode failure
+FREEZE_CORROBORATE_MAX_EVENTS = 12
+FREEZE_PROBE_TIMEOUT_SECS = 120
 
-    Programmes open and close on motionless plates, so the picture genuinely
-    stops and the detector is right; the plate is simply not a defect. The
-    shape is distinctive: one event, only a little longer than the detector's
-    own minimum, hard against one end of the file.
-
-    Returns (kept_events, discounted_cards).
-    """
-    if len(freeze_events) != 1 or not duration:
-        return freeze_events, []
-
-    event = freeze_events[0]
-    start = event.get('start', 0)
-    length = event.get('duration', 0)
-    if _setting('detection.static_card_edge_secs') <= 0:
-        return freeze_events, []
-
-    tail = duration - (start + length)
-    if tail < 0:
-        # The event runs past the reported duration, so the container's
-        # duration is short of the real runtime and says nothing about where
-        # in the programme this sits.
-        return freeze_events, []
-
-    edge_window = min(_setting('detection.static_card_edge_secs'), duration * STATIC_CARD_EDGE_FRACTION)
-    is_card = length <= _setting('detection.static_card_max_secs') and min(start, tail) <= edge_window
-    return ([], [event]) if is_card else (freeze_events, [])
-
-
-# A lone freeze barely past the detector's minimum, hard against either end of
-# a file, is a static title or end card. The edge window is also capped as a
-# fraction of runtime so it cannot stretch across the middle of a short clip
-# and swallow a genuine freeze.
-STATIC_CARD_EDGE_FRACTION = 0.10
-
-# freezedetect's tolerance compares a whole-frame mean, so a held animation cel
-# whose only motion is a few small figures scores below it and reports as
-# frozen even though no two frames match. Candidates are re-checked at a
-# tolerance only truly repeated frames can clear.
-FREEZE_CONFIRM_MIN_SECS = 2.0
-# Each confirmation is its own ffmpeg process, so a file reporting hundreds of
-# events would spend minutes on spawn overhead alone. Past the cap the
-# remaining events are kept unconfirmed, matching the fail-open policy used
-# when the pass times out or ffmpeg is missing.
-# The window cap bounds process count; a wall-time budget bounds what actually
-# matters on a project with no global scan timeout. Both are settings.
+_RE_DECODE_ERROR = re.compile(
+    r'Invalid NAL unit size|Error splitting the input|missing picture'
+    r'|Error submitting packet to decoder|error while decoding MB', re.IGNORECASE)
 
 # A file whose allocated blocks fall short of its nominal size may have holes
 # in it. Compression and dedup under-allocate healthy files too, so the ratio
@@ -2050,13 +2050,20 @@ class PixelProbe:
                 corruption_details.extend(hevc_details)
                 scan_output.extend(hevc_output)
         
-        # Freeze detection - check for stuck frames (warning only, not corruption)
+        # Freeze detection. A corroborated freeze (absent packets, failing
+        # decoder) is corruption; an uncorroborated long freeze is a warning.
         freeze_enabled = _setting('detection.freeze_detection_enabled')
         if freeze_enabled and duration and duration > 0:
-            freeze_detected, freeze_details, freeze_output = self._check_video_freeze(file_path, duration)
-            if freeze_detected:
-                warning_details.extend(freeze_details)
-                scan_output.extend(freeze_output)
+            avg_fps = _parse_rate(video_stream.get('avg_frame_rate')) if video_stream else None
+            frz_corrupted, frz_corruption, frz_warned, frz_warnings, frz_output = \
+                self._check_video_freeze(file_path, duration, avg_fps=avg_fps)
+            if frz_corrupted:
+                is_corrupted = True
+                corruption_details.extend(frz_corruption)
+            if frz_warned:
+                warning_details.extend(frz_warnings)
+            if frz_corrupted or frz_warned:
+                scan_output.extend(frz_output)
 
         # Return warning details as well
         return is_corrupted, corruption_details, scan_tool, scan_output, warning_details
@@ -2324,97 +2331,88 @@ class PixelProbe:
         
         return is_corrupted, corruption_details, hevc_output
 
-    def _confirm_freeze_events(self, file_path, freeze_events):
-        """Re-check each candidate window at a tolerance only repeated frames clear.
+    def _corroborate_freeze(self, file_path, event, avg_fps=None):
+        """What else is true where the picture stopped.
 
-        The main pass uses freezedetect's default noise tolerance, which
-        compares a whole-frame mean. Limited animation holds its background and
-        moves only small figures, which moves that mean by far less than the
-        tolerance - so the segment reports as frozen even though every frame in
-        it differs. Re-running the window with the tolerance near zero keeps
-        genuinely repeated frames and drops the rest.
+        Two independent signals, checked cheapest-first:
+        - a packet probe over the window (no decode): if the stream barely has
+          packets where the clock kept running, content is missing;
+        - a decode of just the window: a flood of decoder errors means the
+          picture stopped because the decoder could not produce frames.
 
-        Returns (confirmed_events, unconfirmed_events). If FFmpeg cannot be run
-        the events are returned unchanged, so a broken confirmation pass can
-        never silently erase findings.
+        Returns ('missing-content'|'decode'|None, detail_line). A probe that
+        fails or times out returns None: corroboration exists to prove damage,
+        and an unprovable event falls through to the uncorroborated path
+        rather than being promoted to corruption on no evidence.
         """
-        confirmed = []
-        unconfirmed = []
-        checked = 0
-        confirm_noise = _setting('detection.freeze_confirm_noise')
-        confirm_timeout = _setting('timeouts.freeze_confirm_timeout_secs')
-        max_windows = _setting('performance.freeze_confirm_max_windows')
-        deadline = time.time() + _setting('performance.freeze_confirm_budget_secs')
-        for event in freeze_events:
-            start = event.get('start', 0)
-            length = event.get('duration', 0)
-            if (length < FREEZE_CONFIRM_MIN_SECS
-                    or checked >= max_windows
-                    or time.time() >= deadline):
-                confirmed.append(event)
-                continue
-            checked += 1
-            try:
-                result = safe_subprocess_run([
-                    'ffmpeg',
-                    '-nostdin',
-                    '-v', 'info',
-                    '-ss', f'{start:.3f}',
-                    '-i', file_path,
-                    '-t', f'{length:.3f}',
-                    '-an', '-sn', '-dn',
-                    '-map', '0:v:0',
-                    '-vf', (f"freezedetect=n={confirm_noise}"
-                            f":d={FREEZE_CONFIRM_MIN_SECS}"),
-                    '-f', 'null',
-                    '-'
-                ], capture_output=True, text=True, timeout=confirm_timeout)
-            except subprocess.TimeoutExpired:
-                logger.warning(
-                    f"Freeze confirmation timed out for {file_path} at {start:.1f}s; "
-                    f"keeping the event")
-                confirmed.append(event)
-                continue
-            except OSError as e:
-                logger.warning(f"Freeze confirmation could not run for {file_path}: {e}")
-                confirmed.append(event)
-                continue
+        start = event.get('start', 0)
+        length = max(event.get('duration', 0), 1.0)
+        lead = max(0.0, start - 3)
+        span = length + 6
 
-            if result.returncode != 0:
-                # A failed run produces stderr with no freezedetect lines,
-                # which is indistinguishable from "frames differ". Keep the
-                # event rather than let a broken run erase a finding.
-                logger.warning(
-                    f"Freeze confirmation exited {result.returncode} for {file_path} "
-                    f"at {start:.1f}s; keeping the event")
-                confirmed.append(event)
-            elif _parse_freeze_events((result.stderr or '').split('\n')):
-                confirmed.append(event)
-            else:
-                unconfirmed.append(event)
+        try:
+            probe = safe_subprocess_run([
+                'ffprobe', '-v', 'error', '-select_streams', 'v:0',
+                '-read_intervals', f'{lead}%+{span}',
+                '-show_entries', 'packet=pts_time', '-of', 'csv=p=0',
+                file_path,
+            ], capture_output=True, text=True, timeout=FREEZE_PROBE_TIMEOUT_SECS)
+            pts = sorted(float(x) for x in (probe.stdout or '').split()
+                         if x.strip() and x.strip() != 'N/A')
+            inside = sum(1 for t in pts if start - 0.05 <= t <= start + length + 0.05)
+            outside = [t for t in pts if t < start - 0.05 or t > start + length + 0.05]
+            if len(pts) > 2 and _steady_cadence(outside):
+                # Absent packets only mean damage on a stream that stores
+                # frames at a steady rhythm. A variable-frame-rate source
+                # (screen recordings, slideshows) legitimately stores nothing
+                # while the picture holds, so an irregular cadence around the
+                # window means this gap proves nothing. Expected packets come
+                # from the file's declared average rate when it has one.
+                rate = avg_fps or len(pts) / max(0.001, pts[-1] - pts[0])
+                expected = length * rate
+                if expected > 5 and inside < expected * FREEZE_PACKET_ABSENT_RATIO:
+                    absent_pct = 100.0 * (1 - inside / expected)
+                    return 'missing-content', (
+                        f"Missing content at {start:.1f}s: {inside} of ~{expected:.0f} "
+                        f"expected packets present ({absent_pct:.0f}% absent over {length:.1f}s)")
+        except (subprocess.TimeoutExpired, OSError, ValueError) as e:
+            logger.debug(f"Freeze packet probe failed for {file_path}: {e}")
 
-        if checked < len(freeze_events):
-            logger.info(
-                f"Freeze confirmation checked {checked} of {len(freeze_events)} event(s) "
-                f"for {file_path}; the rest are reported without being confirmed")
-        if unconfirmed:
-            logger.info(
-                f"Freeze confirmation dropped {len(unconfirmed)} of "
-                f"{len(freeze_events)} event(s) for {file_path} (frames differ)")
-        return confirmed, unconfirmed
+        try:
+            decode = safe_subprocess_run([
+                'ffmpeg', '-nostdin', '-v', 'error',
+                '-ss', f'{start:.3f}', '-i', file_path, '-t', f'{length:.3f}',
+                '-an', '-sn', '-dn', '-map', '0:v:0', '-f', 'null', '-',
+            ], capture_output=True, text=True, timeout=FREEZE_PROBE_TIMEOUT_SECS)
+            errors = len(_RE_DECODE_ERROR.findall(decode.stderr or ''))
+            if errors > FREEZE_DECODE_ERROR_MIN:
+                return 'decode', (
+                    f"Decode failure at {start:.1f}s: {errors} decoder error(s) "
+                    f"over {length:.1f}s - the picture held because no frames could be produced")
+        except (subprocess.TimeoutExpired, OSError) as e:
+            logger.debug(f"Freeze decode probe failed for {file_path}: {e}")
 
-    def _check_video_freeze(self, file_path, duration):
-        """Detect frozen video frames using FFmpeg's freezedetect filter.
+        return None, None
 
-        A freeze is where the video picture stops changing while time (and audio)
-        continues.  Uses the lavfi freezedetect filter with a 5-second minimum
-        duration and -60 dB noise tolerance.  Black frame sections detected by
-        blackdetect are used to filter false positives from scene transitions,
-        studio logos, and end credits.
+    def _check_video_freeze(self, file_path, duration, avg_fps=None):
+        """Detect frozen video and decide whether the freeze is damage.
 
-        Returns (has_warnings, warning_details, scan_output).
+        freezedetect finds stretches where the picture stops changing. That
+        alone does not separate damage from intent: a held animation cel and a
+        static title card also stop the picture. So every candidate is
+        corroborated against the file itself - absent packets or a failing
+        decoder make it a corruption verdict; a freeze with neither signal is
+        the picture stopping on purpose and is discounted, unless a single
+        event runs past the uncorroborated minimum, which stays a warning so a
+        genuinely stuck source (valid frames, nothing else wrong) is not
+        silent. Black-frame overlaps are filtered first, as before.
+
+        Returns (is_corrupted, corruption_details, has_warnings,
+        warning_details, scan_output).
         """
+        corruption_details = []
         warning_details = []
+        is_corrupted = False
         has_warnings = False
         scan_output = []
 
@@ -2492,51 +2490,81 @@ class PixelProbe:
                     )
                 freeze_events = filtered
 
-            # A lone short freeze against either end of the file is a static
-            # title or end card, not a defect
-            freeze_events, cards = _drop_static_cards(freeze_events, duration)
-            for card in cards:
+            # Corroborate: a real freeze has a cause the file can show us.
+            # Either the packets are absent where the clock kept running, or
+            # the decoder is failing to produce pictures. Both are corruption
+            # verdicts, not warnings. An event with neither signal is a held
+            # animation cel or a static title/end card doing its job.
+            corroborated = []
+            uncorroborated = []
+            for index, event in enumerate(freeze_events):
+                if index >= FREEZE_CORROBORATE_MAX_EVENTS:
+                    uncorroborated.append(event)
+                    continue
+                cause, detail = self._corroborate_freeze(file_path, event, avg_fps)
+                if cause:
+                    corroborated.append((cause, detail, event))
+                else:
+                    uncorroborated.append(event)
+            if len(freeze_events) > FREEZE_CORROBORATE_MAX_EVENTS:
                 scan_output.append(
-                    f"Discounted static card at {card.get('start', 0):.1f}s "
-                    f"({card.get('duration', 0):.1f}s) - title or end card, not a defect"
-                )
+                    f"Corroborated the first {FREEZE_CORROBORATE_MAX_EVENTS} of "
+                    f"{len(freeze_events)} freeze event(s)")
 
-            # Confirm what is left against a tolerance only repeated frames can
-            # clear, so held animation cels do not read as frozen video
-            freeze_events, unconfirmed = self._confirm_freeze_events(file_path, freeze_events)
-            for event in unconfirmed:
+            if corroborated:
+                is_corrupted = True
+                causes = sorted({c for c, _, _ in corroborated})
+                n = len(corroborated)
+                if causes == ['missing-content']:
+                    summary = f"Missing content: {n} frozen segment(s) with absent packets"
+                elif causes == ['decode']:
+                    summary = f"Decode failure: {n} frozen segment(s) with decoder errors"
+                else:
+                    summary = (f"Damaged video: {n} frozen segment(s) with "
+                               f"missing packets or decoder errors")
+                corruption_details.append(summary)
+                scan_output.append(summary)
+                for _, detail, _ in corroborated[:10]:
+                    scan_output.append(f"  {detail}")
+                logger.warning(
+                    f"Corroborated freeze damage in {file_path}: {summary}")
+
+            long_minimum = _setting('detection.freeze_uncorroborated_min_secs')
+            reportable = [e for e in uncorroborated
+                          if e.get('duration', 0) >= long_minimum]
+            discounted = [e for e in uncorroborated
+                          if e.get('duration', 0) < long_minimum]
+            for event in discounted:
                 scan_output.append(
-                    f"Discounted near-static segment at {event.get('start', 0):.1f}s "
-                    f"({event.get('duration', 0):.1f}s) - frames differ, picture is not frozen"
-                )
+                    f"Discounted still segment at {event.get('start', 0):.1f}s "
+                    f"({event.get('duration', 0):.1f}s) - packets present and decodable, "
+                    f"the picture stopped on purpose")
 
-            if freeze_events:
+            if reportable:
                 has_warnings = True
-                total_frozen = min(_merged_frozen_seconds(freeze_events), duration)
+                total_frozen = min(_merged_frozen_seconds(reportable), duration)
                 frozen_pct = min(total_frozen / duration * 100, 100.0)
 
                 summary = (
-                    f"Video freeze warning: {len(freeze_events)} event(s), "
+                    f"Video freeze warning: {len(reportable)} event(s), "
                     f"{total_frozen:.1f}s frozen ({frozen_pct:.1f}% of video)"
                 )
                 warning_details.append(summary)
                 scan_output.append(summary)
 
-                for i, event in enumerate(freeze_events[:10]):
-                    start = event.get('start', 0)
-                    end = event.get('end', 0)
-                    dur = event.get('duration', 0)
+                for i, event in enumerate(reportable[:10]):
                     scan_output.append(
-                        f"  Freeze #{i + 1}: {start:.1f}s - {end:.1f}s (duration: {dur:.1f}s)"
+                        f"  Freeze #{i + 1}: {event.get('start', 0):.1f}s - "
+                        f"{event.get('end', 0):.1f}s (duration: {event.get('duration', 0):.1f}s)"
                     )
-                if len(freeze_events) > 10:
-                    scan_output.append(f"  ... and {len(freeze_events) - 10} more freeze event(s)")
+                if len(reportable) > 10:
+                    scan_output.append(f"  ... and {len(reportable) - 10} more freeze event(s)")
 
                 logger.info(
-                    f"Freeze warning in {file_path}: {len(freeze_events)} event(s), "
+                    f"Freeze warning in {file_path}: {len(reportable)} event(s), "
                     f"{total_frozen:.1f}s total frozen"
                 )
-            else:
+            if not corroborated and not reportable:
                 scan_output.append("No freeze events detected")
                 logger.info(f"No freeze detected in {file_path}")
 
@@ -2552,7 +2580,7 @@ class PixelProbe:
             logger.debug(f"Freeze detection error for {file_path}: {str(e)}")
 
         scan_output.append("=== Freeze Detection Complete ===")
-        return has_warnings, warning_details, scan_output
+        return is_corrupted, corruption_details, has_warnings, warning_details, scan_output
 
     def _enhanced_corruption_check(self, file_path, file_size_gb, duration=None):
         """Enhanced multi-stage corruption detection for files that fail basic checks
@@ -3144,6 +3172,10 @@ class PixelProbe:
                 # hash. Baseline updates for flagged files happen only via
                 # auto-expire or the manual accept action.
                 logger.info(f"Preserving hash/mtime baseline for bitrot-suspected file: {file_path}")
+            if retire_stale_override(db_result, scan_result.get('file_hash'),
+                                     scan_result.get('corruption_details'),
+                                     scan_result.get('warning_details')):
+                logger.info(f"Override retired for {file_path}: new findings outside its scope")
             db_result.is_corrupted = scan_result.get('is_corrupted', False)
             db_result.corruption_details = scan_result.get('corruption_details')
             db_result.scan_tool = scan_result.get('scan_tool')

--- a/pixelprobe/migrations/startup.py
+++ b/pixelprobe/migrations/startup.py
@@ -13,6 +13,7 @@ from sqlalchemy import text, inspect, exc
 from pixelprobe.constants import (CONFIG_LOG_RETENTION_DAYS, CONFIG_LOG_EXCLUDE_LOGGERS,
                                   DEFAULT_LOG_EXCLUDE_LOGGERS, SCANNER_SETTINGS)
 from pixelprobe.utils.helpers import env_int
+from pixelprobe.utils.overrides import classify_findings, encode_verdict
 
 logger = logging.getLogger(__name__)
 
@@ -454,6 +455,54 @@ def run_v2_8_7_migrations(db):
         logger.error(f"Migration v2.8.7 failed: {e}")
 
 
+def run_v2_8_8_migrations(db):
+    """Scope the mark-as-good override to what was actually excused.
+
+    Adds the columns recording which file version and which finding class a
+    mark-as-good judged. Existing marked rows are backfilled treating the
+    upgrade as the review moment: the current hash becomes the reviewed hash,
+    and the excused class is derived from whatever details the row carries.
+    Rows with no stored details keep a NULL verdict, which excuses everything,
+    so a mark placed before scoping existed keeps its old behaviour.
+    """
+    try:
+        with migration_connection(db) as conn:
+            existing = {c['name'] for c in inspect(conn).get_columns('scan_results')}
+            for name, ddl in (
+                ('marked_good_hash', 'VARCHAR(64)'),
+                ('marked_good_date', 'TIMESTAMP'),
+                ('marked_good_verdict', 'VARCHAR(128)'),
+            ):
+                if name not in existing:
+                    conn.execute(text(f'ALTER TABLE scan_results ADD COLUMN {name} {ddl}'))
+                    logger.info(f"Added scan_results.{name}")
+            # Commit the columns before touching rows: a backfill failure must
+            # leave the schema in place (the model declares these columns, so
+            # rolling them back would fail every ScanResult query app-wide)
+            conn.commit()
+
+            rows = conn.execute(text("""
+                SELECT id, corruption_details, warning_details
+                FROM scan_results
+                WHERE marked_as_good = TRUE AND marked_good_date IS NULL
+            """)).fetchall()
+            for row in rows:
+                verdict = encode_verdict(classify_findings(row[1], row[2]))
+                conn.execute(text("""
+                    UPDATE scan_results
+                    SET marked_good_hash = file_hash,
+                        marked_good_date = (now() AT TIME ZONE 'utc'),
+                        marked_good_verdict = :verdict
+                    WHERE id = :id
+                """), {'id': row[0], 'verdict': verdict})
+            conn.commit()
+            if rows:
+                logger.info(f"Backfilled override scope for {len(rows)} marked-good file(s)")
+
+    except Exception as e:
+        logger.error(f"Migration v2.8.8 failed: {e}")
+
+
 def create_performance_indexes(db):
     """Create performance indexes"""
     indexes = [
@@ -498,6 +547,12 @@ def _run_all_migrations(db):
         logger.info("Startup migrations completed successfully")
     except Exception as e:
         logger.error(f"Startup migration failed: {e}")
+
+    logger.info("Scoping mark-as-good overrides...")
+    try:
+        run_v2_8_8_migrations(db)
+    except Exception as e:
+        logger.error(f"v2.8.8 migration failed: {e}")
 
     logger.info("Adopting scanner settings from the environment...")
     try:

--- a/pixelprobe/models.py
+++ b/pixelprobe/models.py
@@ -42,6 +42,15 @@ class ScanResult(db.Model):
     corruption_details = db.Column(db.Text)
     scan_date = db.Column(db.DateTime, nullable=True, index=True)  # NULL = not scanned yet
     marked_as_good = db.Column(db.Boolean, nullable=False, default=False, index=True)
+    # A mark-as-good is a judgement about one finding on one version of the
+    # file, not a permanent mute on the file. These record what was excused so
+    # the scan write path can retire the override when the content changes or
+    # a different class of finding appears. Date and verdict stay set after the
+    # override lapses, so "files that were excused" remains queryable (the
+    # bitrot columns follow the same keep-history pattern).
+    marked_good_hash = db.Column(db.String(64), nullable=True)
+    marked_good_date = db.Column(db.DateTime, nullable=True)
+    marked_good_verdict = db.Column(db.String(128), nullable=True)
     scan_status = db.Column(db.String(20), nullable=True, default='pending', index=True)  # pending, scanning, completed, error
     discovered_date = db.Column(db.DateTime, nullable=True, default=None, index=True)  # When file was discovered
     
@@ -112,6 +121,8 @@ class ScanResult(db.Model):
             'corruption_details': self.corruption_details,
             'scan_date': convert_to_tz(self.scan_date),
             'marked_as_good': self.marked_as_good,
+            'marked_good_date': convert_to_tz(self.marked_good_date),
+            'marked_good_verdict': self.marked_good_verdict,
             'scan_status': self.scan_status,
             'file_hash': self.file_hash,
             'last_modified': convert_to_tz(self.last_modified),

--- a/pixelprobe/tasks_parallel.py
+++ b/pixelprobe/tasks_parallel.py
@@ -36,6 +36,7 @@ from pixelprobe.models import db, ScanState, ScanResult, ScanChunk
 from pixelprobe.media_checker import PixelProbe, load_exclusions_with_patterns
 from pixelprobe.progress_utils import clear_scan_progress_redis, update_scan_progress_redis
 from pixelprobe.utils.integrity import apply_scan_baseline
+from pixelprobe.utils.overrides import retire_stale_override
 from pixelprobe.services.scan_engine import (
     build_scan_chunks, claim_scan_slot, finalize_scan,
     maybe_finalize_scan, sync_progress_from_chunks
@@ -304,6 +305,15 @@ def process_chunk_task(self, chunk_db_id: int, scan_id: str, force_rescan: bool 
                                     warning_details = corruption_details
                         if warning_details and not has_warnings:
                             has_warnings = True
+
+                        # A mark-as-good excused one finding class on one
+                        # version of the file; different content or a different
+                        # class of problem retires it (history columns stay)
+                        if retire_stale_override(db_result, scan_result.get('file_hash'),
+                                                 corruption_details, warning_details):
+                            logger.info(
+                                f"Override retired for {file_path}: new findings "
+                                f"outside its scope")
 
                         db_result.is_corrupted = is_corrupted
                         db_result.scan_status = 'completed'

--- a/pixelprobe/utils/overrides.py
+++ b/pixelprobe/utils/overrides.py
@@ -1,0 +1,113 @@
+"""Scoping for the mark-as-good override.
+
+Marking a file good is a judgement about one finding on one version of the
+file, made by a person who looked at the evidence. It is not a promise that
+the file will be fine forever. These helpers decide whether a stored override
+still applies to a fresh scan result:
+
+- The content changed (hash differs): this is not the file that was reviewed,
+  so the override lapses and the new verdict stands.
+- A different class of finding appeared: the person excused a freeze warning,
+  not a missing-content verdict, so the override lapses.
+- Same content, same class of finding: the override holds.
+
+Kept free of Flask and Celery imports so both the web process and the scan
+workers can use it, and it stays unit-testable.
+"""
+
+# Every matching class is collected; order carries no precedence. Markers must
+# match the strings the scanner actually emits (see media_checker.py) - a
+# marker that matches nothing quietly turns its findings into 'other'.
+_FINDING_MARKERS = (
+    ('incomplete', ('incomplete file',)),
+    ('missing-content', ('missing content',)),
+    ('decode', ('decode failure', 'decoding errors', 'hevc reference picture',
+                'ffmpeg errors')),
+    ('freeze', ('video freeze warning',)),
+    ('frame-count', ('count differs',)),
+    ('temporal', ('temporal outlier', 'vertical line repetition', 'tout')),
+    ('timestamp', ('timestamps detected', 'timestamp inconsistencies',
+                   'timestamp warning')),
+)
+
+# The mixed-cause freeze summary names both underlying causes.
+_COMPOUND_MARKERS = (
+    ('damaged video', ('missing-content', 'decode')),
+)
+
+
+def classify_findings(*detail_texts):
+    """The set of finding classes present in corruption/warning detail text.
+
+    Returns a sorted tuple of class names; unrecognised findings map to
+    'other' so they can never hide behind an override scoped to something
+    else.
+    """
+    classes = set()
+    for text in detail_texts:
+        if not text:
+            continue
+        # Details are stored '; '-joined; classify each finding on its own so
+        # an unrecognised one cannot hide behind a recognised neighbour.
+        for fragment in text.split('; '):
+            fragment = fragment.strip()
+            if not fragment:
+                continue
+            lowered = fragment.lower()
+            matched = False
+            for name, compound in _COMPOUND_MARKERS:
+                if name in lowered:
+                    classes.update(compound)
+                    matched = True
+            for name, markers in _FINDING_MARKERS:
+                if any(marker in lowered for marker in markers):
+                    classes.add(name)
+                    matched = True
+            if not matched:
+                classes.add('other')
+    return tuple(sorted(classes))
+
+
+def encode_verdict(classes):
+    """Store a class set as the comma-joined string the model column holds."""
+    return ','.join(classes) if classes else None
+
+
+def override_still_applies(marked_good_hash, marked_good_verdict,
+                           current_hash, corruption_details, warning_details):
+    """Whether a stored override covers this fresh scan result.
+
+    A missing stored hash keeps legacy behaviour (content changes cannot be
+    detected, so only the class check applies). A NULL stored verdict excuses
+    every class, again for legacy rows marked before scoping existed.
+    """
+    if marked_good_hash and current_hash and marked_good_hash != current_hash:
+        return False
+
+    if marked_good_verdict is None:
+        # A NULL stored verdict excuses everything (rows marked before scoping)
+        return True
+
+    excused = set(marked_good_verdict.split(','))
+    found = set(classify_findings(corruption_details, warning_details))
+    return found <= excused
+
+
+def retire_stale_override(db_result, current_hash, corruption_details, warning_details):
+    """Clear marked_as_good on a row whose override no longer covers the result.
+
+    Mutates the row and returns True when the override was retired. The
+    history columns (hash, date, verdict) stay set. Call from every path that
+    persists a fresh scan result, or a single-file rescan will keep reporting
+    a damaged file as healthy.
+    """
+    if not db_result.marked_as_good:
+        return False
+    if not (corruption_details or warning_details):
+        return False
+    if override_still_applies(db_result.marked_good_hash,
+                              db_result.marked_good_verdict,
+                              current_hash, corruption_details, warning_details):
+        return False
+    db_result.marked_as_good = False
+    return True

--- a/pixelprobe/version.py
+++ b/pixelprobe/version.py
@@ -4,7 +4,7 @@ import os
 # Default version - this is the single source of truth
 
 
-_DEFAULT_VERSION = '2.8.7'
+_DEFAULT_VERSION = '2.8.8'
 
 
 # Allow override via environment variable for CI/CD, but default to the hardcoded version

--- a/tests/test_media_checker.py
+++ b/tests/test_media_checker.py
@@ -24,6 +24,31 @@ def patch_settings(**overrides):
                  return_value=settings_with(**overrides))
 
 
+def freeze_router(freeze_stderr='', probe_stdout='', decode_stderr=''):
+    """subprocess.run side_effect for the freeze path's three processes.
+
+    The main detection pass carries 'freezedetect' in its filter argument; the
+    corroboration packet probe is ffprobe; the corroboration window decode is
+    an ffmpeg null decode with no filter. Defaults corroborate nothing, so
+    events fall through to the uncorroborated path.
+    """
+    def side_effect(cmd, *args, **kwargs):
+        result = Mock()
+        result.returncode = 0
+        joined = ' '.join(str(part) for part in cmd)
+        if str(cmd[0]).endswith('ffprobe'):
+            result.stdout = probe_stdout
+            result.stderr = ''
+        elif 'freezedetect' in joined:
+            result.stdout = ''
+            result.stderr = freeze_stderr
+        else:
+            result.stdout = ''
+            result.stderr = decode_stderr
+        return result
+    return side_effect
+
+
 class TestMediaChecker:
     """Test the core PixelProbe media checking functionality"""
     
@@ -421,27 +446,6 @@ class TestMediaChecker:
 class TestVideoFreezeDetection:
     """Test video freeze detection via FFmpeg freezedetect filter"""
 
-    def _make_freezedetect_stderr(self, events):
-        """Build fake FFmpeg stderr containing freezedetect log lines.
-
-        Args:
-            events: list of (start, end, duration) tuples
-        """
-        lines = []
-        # Real ffmpeg emission order per event: freeze_start, then at unfreeze
-        # freeze_duration followed by freeze_end (verified against ffmpeg 8).
-        for start, end, duration in events:
-            lines.append(
-                f"[freezedetect @ 0x1234] lavfi.freezedetect.freeze_start: {start}"
-            )
-            lines.append(
-                f"[freezedetect @ 0x1234] lavfi.freezedetect.freeze_duration: {duration}"
-            )
-            lines.append(
-                f"[freezedetect @ 0x1234] lavfi.freezedetect.freeze_end: {end}"
-            )
-        return "\n".join(lines)
-
     def _make_blackdetect_stderr(self, events):
         """Build fake FFmpeg stderr containing blackdetect log lines.
 
@@ -456,30 +460,24 @@ class TestVideoFreezeDetection:
         return "\n".join(lines)
 
     @patch('subprocess.run')
-    def test_video_freeze_detection(self, mock_run):
-        """Freeze events are detected and returned as warnings"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = self._make_freezedetect_stderr([
-            (10.0, 15.0, 5.0),
-            (45.5, 50.0, 4.5),
-        ])
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
+    def test_video_freeze_detection_pairs_events_correctly(self, mock_run):
+        """Each event pairs its own start and end, not a neighbor's"""
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=_freeze_stderr([
+                (10.0, 75.0, 65.0),
+                (100.0, 170.5, 70.5),
+            ]),
+            probe_stdout=_packets(7.0, 174.0))
 
         checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/video.mp4', duration=120.0
-        )
+        is_corrupted, _, has_warnings, warning_details, scan_output = \
+            checker._check_video_freeze('/fake/video.mp4', duration=300.0)
 
+        assert is_corrupted is False
         assert has_warnings is True
-        assert len(warning_details) == 1
         assert '2 event(s)' in warning_details[0]
-        assert '9.5s frozen' in warning_details[0]
-        assert '7.9%' in warning_details[0]
-        # Each event must pair its own start and end, not a neighbor's
-        assert any('Freeze #1: 10.0s - 15.0s (duration: 5.0s)' in line for line in scan_output)
-        assert any('Freeze #2: 45.5s - 50.0s (duration: 4.5s)' in line for line in scan_output)
+        assert any('Freeze #1: 10.0s - 75.0s (duration: 65.0s)' in line for line in scan_output)
+        assert any('Freeze #2: 100.0s - 170.5s (duration: 70.5s)' in line for line in scan_output)
 
     @patch('subprocess.run')
     def test_video_no_freeze(self, mock_run):
@@ -491,7 +489,7 @@ class TestVideoFreezeDetection:
         mock_run.return_value = mock_result
 
         checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
+        _, _, has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/clean.mp4', duration=40.0
         )
 
@@ -505,7 +503,7 @@ class TestVideoFreezeDetection:
         mock_run.side_effect = subprocess.TimeoutExpired(cmd='ffmpeg', timeout=60)
 
         checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
+        _, _, has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/big.mp4', duration=30.0
         )
 
@@ -530,28 +528,19 @@ class TestVideoFreezeDetection:
                 'codec_name': 'h264',
                 'profile': 'High',
                 'pix_fmt': 'yuv420p',
-                'duration': '60.0'
+                'duration': '300.0'
             }],
             'format': {
-                'duration': '60.0'
+                'duration': '300.0'
             }
         }
 
-        # All subprocess calls return clean except freeze detection
-        def subprocess_side_effect(cmd, *args, **kwargs):
-            result = Mock()
-            result.returncode = 0
-            result.stdout = ''
-            # Detect the freezedetect call by checking for the filter arg.
-            # The event sits in the body of the file: an event against either
-            # edge is a title or end card and is discounted by design.
-            if any('freezedetect' in str(arg) for arg in cmd):
-                result.stderr = self._make_freezedetect_stderr([(25.0, 30.0, 5.0)])
-            else:
-                result.stderr = ''
-            return result
-
-        mock_run.side_effect = subprocess_side_effect
+        # All subprocess calls return clean except the freeze pass. The event
+        # is uncorroborated but longer than the excuse threshold, which is the
+        # shape that propagates as a warning under corroboration.
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=_freeze_stderr([(100.0, 170.0, 70.0)]),
+            probe_stdout=_packets(97.0, 174.0))
 
         checker = PixelProbe()
         is_corrupted, corruption_details, scan_tool, scan_output, warning_details = (
@@ -577,7 +566,7 @@ class TestVideoFreezeDetection:
         mock_run.return_value = mock_result
 
         checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
+        _, _, has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/cutoff.mp4', duration=60.0
         )
 
@@ -615,7 +604,7 @@ class TestVideoFreezeDetection:
             result.returncode = 0
             result.stdout = ''
             if any('freezedetect' in str(arg) for arg in cmd):
-                result.stderr = self._make_freezedetect_stderr([(5.0, 10.0, 5.0)])
+                result.stderr = _freeze_stderr([(5.0, 10.0, 5.0)])
             else:
                 result.stderr = ''
             return result
@@ -638,23 +627,23 @@ class TestVideoFreezeDetection:
         """Freeze events overlapping black sections are filtered as false positives"""
         # Freeze at 0-3s and 100-105s, black at 0-4s and 99-106s
         # Both freezes overlap black -- should be filtered out entirely
-        freeze_stderr = self._make_freezedetect_stderr([
-            (0.0, 3.0, 3.0),
-            (100.0, 105.0, 5.0),
+        # Long freezes over black would otherwise pass the uncorroborated
+        # minimum and warn; the black filter is what keeps a fade-out quiet.
+        freeze_stderr = _freeze_stderr([
+            (0.0, 70.0, 70.0),
+            (100.0, 165.0, 65.0),
         ])
         black_stderr = self._make_blackdetect_stderr([
-            (0.0, 4.0, 4.0),
-            (99.0, 106.0, 7.0),
+            (0.0, 71.0, 71.0),
+            (99.0, 166.0, 67.0),
         ])
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = freeze_stderr + "\n" + black_stderr
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=freeze_stderr + "\n" + black_stderr,
+            probe_stdout=_packets(0.0, 170.0))
 
         checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/transitions.mp4', duration=120.0
+        _, _, has_warnings, warning_details, scan_output = checker._check_video_freeze(
+            '/fake/transitions.mp4', duration=200.0
         )
 
         assert has_warnings is False
@@ -665,22 +654,20 @@ class TestVideoFreezeDetection:
     def test_video_freeze_real_freeze_not_filtered(self, mock_run):
         """Freeze on actual content (no black overlap) is still flagged"""
         # Freeze at 50-55s on real content, black only at 0-2s (opening)
-        freeze_stderr = self._make_freezedetect_stderr([
-            (0.0, 2.0, 2.0),    # overlaps black -- filtered
-            (50.0, 55.0, 5.0),  # no black overlap -- kept
+        freeze_stderr = _freeze_stderr([
+            (0.0, 62.0, 62.0),    # overlaps black -- filtered
+            (100.0, 165.0, 65.0),  # no black overlap -- kept, uncorroborated but long
         ])
         black_stderr = self._make_blackdetect_stderr([
-            (0.0, 2.5, 2.5),
+            (0.0, 63.0, 63.0),
         ])
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = freeze_stderr + "\n" + black_stderr
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=freeze_stderr + "\n" + black_stderr,
+            probe_stdout=_packets(0.0, 170.0))
 
         checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/real_freeze.mp4', duration=120.0
+        _, _, has_warnings, warning_details, scan_output = checker._check_video_freeze(
+            '/fake/real_freeze.mp4', duration=300.0
         )
 
         assert has_warnings is True
@@ -689,226 +676,127 @@ class TestVideoFreezeDetection:
         assert any('Filtered 1 of 2' in line for line in scan_output)
 
 
-class TestStaticCardSuppression:
-    """Static title and end cards are real freezes but not defects"""
+def _freeze_stderr(events):
+    """freezedetect stderr lines in real ffmpeg emission order."""
+    lines = []
+    for start, end, duration in events:
+        lines.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: {start}")
+        lines.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_duration: {duration}")
+        lines.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_end: {end}")
+    return "\n".join(lines)
 
-    def _stderr(self, events):
-        lines = []
-        for start, end, duration in events:
-            lines.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: {start}")
-            lines.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_duration: {duration}")
-            lines.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_end: {end}")
-        return "\n".join(lines)
+
+def _packets(start, end, step=0.04):
+    """ffprobe csv stdout: one pts per line across [start, end)."""
+    out = []
+    t = start
+    while t < end:
+        out.append(f"{t:.3f}")
+        t += step
+    return "\n".join(out)
+
+
+class TestFreezeCorroboration:
+    """A freeze is damage only when the file can show why the picture stopped"""
+
+    def _run(self, mock_run, events, duration=1290.0, probe_stdout=None, decode_stderr=''):
+        # Default probe: packets present across the whole probed span, so
+        # nothing is corroborated unless a test says otherwise.
+        if probe_stdout is None:
+            lo = min(e[0] for e in events) - 3
+            hi = max(e[1] for e in events) + 3
+            probe_stdout = _packets(max(0, lo), hi)
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=_freeze_stderr(events),
+            probe_stdout=probe_stdout,
+            decode_stderr=decode_stderr)
+        checker = PixelProbe()
+        return checker._check_video_freeze('/fake/video.mkv', duration=duration)
 
     @patch('subprocess.run')
-    def test_end_card_discounted(self, mock_run):
-        """A lone short freeze just before the last frame is an end card"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = self._stderr([(2628.8, 2633.8, 5.0)])
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/episode.mkv', duration=2641.6
-        )
-
-        assert has_warnings is False
-        assert warning_details == []
-        assert any('Discounted static card at 2628.8s' in line for line in scan_output)
+    def test_uncorroborated_freeze_is_discounted(self, mock_run):
+        """Packets present, frames decodable: the picture stopped on purpose"""
+        c, cd, w, wd, out = self._run(mock_run, [(640.0, 648.0, 8.0)])
+        assert c is False and w is False
+        assert cd == [] and wd == []
+        assert any('Discounted still segment at 640.0s' in line for line in out)
 
     @patch('subprocess.run')
-    def test_title_card_discounted(self, mock_run):
-        """A lone short freeze at the head of the file is a title card"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = self._stderr([(8.1, 18.2, 10.1)])
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/episode.mkv', duration=1290.0
-        )
-
-        assert has_warnings is False
-        assert any('Discounted static card at 8.1s' in line for line in scan_output)
+    def test_end_card_is_discounted_without_a_special_rule(self, mock_run):
+        """The card shape needs no edge-window rule: it is simply uncorroborated"""
+        c, cd, w, wd, out = self._run(mock_run, [(2628.8, 2633.8, 7.0)], duration=2641.6)
+        assert c is False and w is False
 
     @patch('subprocess.run')
-    def test_mid_programme_freeze_kept(self, mock_run):
-        """A freeze in the body of the programme is not a card"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = self._stderr([(640.0, 645.0, 5.0)])
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/episode.mkv', duration=1290.0
-        )
-
-        assert has_warnings is True
-        assert '1 event(s)' in warning_details[0]
+    def test_absent_packets_are_a_corruption_verdict(self, mock_run):
+        """87-100% of packets missing in the window means content is absent"""
+        # Packets exist only in the 3s lead-in and tail, none inside the event
+        probe = _packets(637.0, 640.0) + "\n" + _packets(648.0, 651.0)
+        c, cd, w, wd, out = self._run(mock_run, [(640.0, 648.0, 8.0)], probe_stdout=probe)
+        assert c is True and w is False
+        assert any('Missing content' in d for d in cd)
+        assert any('absent' in line for line in out)
 
     @patch('subprocess.run')
-    def test_long_edge_freeze_kept(self, mock_run):
-        """An edge freeze far longer than a card is still reported"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = self._stderr([(5.0, 65.0, 60.0)])
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/episode.mkv', duration=1290.0
-        )
-
-        assert has_warnings is True
+    def test_decoder_errors_are_a_corruption_verdict(self, mock_run):
+        """A flood of decoder errors means the picture held because it had to"""
+        errors = "\n".join("[h264 @ 0x1] Invalid NAL unit size (0 > 100)." for _ in range(50))
+        c, cd, w, wd, out = self._run(
+            mock_run, [(4019.7, 4130.5, 110.8)], duration=6990.0,
+            probe_stdout=_packets(4016.0, 4137.0), decode_stderr=errors)
+        assert c is True
+        assert any('Decode failure' in d for d in cd)
 
     @patch('subprocess.run')
-    def test_short_clip_middle_freeze_kept(self, mock_run):
-        """On a short clip the edge window must not stretch across the middle"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = self._stderr([(50.0, 55.0, 5.0)])
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/clip.mp4', duration=120.0
-        )
-
-        assert has_warnings is True
-        assert not any('Discounted static card' in line for line in scan_output)
+    def test_long_uncorroborated_freeze_stays_a_warning(self, mock_run):
+        """A stuck source with valid frames must not be silent"""
+        c, cd, w, wd, out = self._run(mock_run, [(100.0, 175.0, 75.0)])
+        assert c is False and w is True
+        assert 'Video freeze warning: 1 event(s)' in wd[0]
 
     @patch('subprocess.run')
-    def test_two_events_never_treated_as_cards(self, mock_run):
-        """Card suppression applies only to a solitary event"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = self._stderr([(2.0, 7.0, 5.0), (1280.0, 1285.0, 5.0)])
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/episode.mkv', duration=1290.0
-        )
-
-        assert has_warnings is True
-        assert '2 event(s)' in warning_details[0]
-
+    def test_uncorroborated_minimum_is_a_setting(self, mock_run):
+        """Lowering the excuse threshold reports shorter uncorroborated freezes"""
+        with patch_settings(**{'detection.freeze_uncorroborated_min_secs': 10.0}):
+            c, cd, w, wd, out = self._run(mock_run, [(640.0, 655.0, 15.0)])
+        assert w is True
 
     @patch('subprocess.run')
-    def test_event_past_reported_duration_is_not_a_card(self, mock_run):
-        """A short container duration must not turn a mid-file freeze into a card"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = self._stderr([(700.0, 710.0, 10.0)])
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
+    def test_variable_rate_stillness_is_not_missing_content(self, mock_run):
+        """A source that stores frames only when the picture changes proves nothing
+        by having no packets in a held stretch"""
+        # Irregular cadence around the window: bursts and long legitimate gaps
+        lead = [70.0, 70.04, 70.08, 74.5, 74.54, 81.0, 88.2, 88.24, 95.0, 95.04]
+        tail = [122.0, 122.04, 131.5, 140.0, 140.04, 152.0]
+        probe = "\n".join(f"{t:.3f}" for t in lead + tail)
+        c, cd, w, wd, out = self._run(
+            mock_run, [(100.0, 120.0, 20.0)], probe_stdout=probe)
+        assert c is False
+        assert cd == []
 
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/short_duration.mkv', duration=600.0
-        )
-
-        assert has_warnings is True
-        assert not any('Discounted static card' in line for line in scan_output)
-
-
-class TestFreezeConfirmationPass:
-    """Held animation cels report as frozen but every frame differs"""
-
-    MAIN = (
-        "[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: 640.0\n"
-        "[freezedetect @ 0x1] lavfi.freezedetect.freeze_duration: 5.0\n"
-        "[freezedetect @ 0x1] lavfi.freezedetect.freeze_end: 645.0"
-    )
-
-    def _dispatch(self, confirm_stderr=None, raises=None, confirm_returncode=0):
-        """Route the main detection pass and the confirmation pass separately"""
+    @patch('subprocess.run')
+    def test_probe_failure_never_promotes_to_corruption(self, mock_run):
+        """No evidence means uncorroborated, not guilty"""
         def side_effect(cmd, *args, **kwargs):
-            is_confirm = 'blackdetect' not in ' '.join(str(part) for part in cmd)
-            if is_confirm and raises is not None:
-                raise raises
+            joined = ' '.join(str(part) for part in cmd)
+            if str(cmd[0]).endswith('ffprobe') or 'freezedetect' not in joined:
+                raise subprocess.TimeoutExpired(cmd='probe', timeout=120)
             result = Mock()
-            result.returncode = confirm_returncode if is_confirm else 0
+            result.returncode = 0
             result.stdout = ''
-            result.stderr = confirm_stderr if is_confirm else self.MAIN
+            result.stderr = _freeze_stderr([(640.0, 648.0, 8.0)])
             return result
-        return side_effect
+        mock_run.side_effect = side_effect
+        checker = PixelProbe()
+        c, cd, w, wd, out = checker._check_video_freeze('/fake/video.mkv', duration=1290.0)
+        assert c is False and w is False
 
     @patch('subprocess.run')
-    def test_unconfirmed_segment_dropped(self, mock_run):
-        """Frames that all differ are not a frozen picture"""
-        mock_run.side_effect = self._dispatch('frame=120 fps=60 time=00:00:05.00')
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/cartoon.mkv', duration=1290.0
-        )
-
-        assert has_warnings is False
-        assert warning_details == []
-        assert any('Discounted near-static segment at 640.0s' in line for line in scan_output)
-
-    @patch('subprocess.run')
-    def test_confirmed_segment_kept(self, mock_run):
-        """Genuinely repeated frames survive confirmation"""
-        mock_run.side_effect = self._dispatch(self.MAIN)
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/stuck.mkv', duration=1290.0
-        )
-
-        assert has_warnings is True
-        assert '1 event(s)' in warning_details[0]
-
-    @patch('subprocess.run')
-    def test_confirmation_failure_keeps_event(self, mock_run):
-        """A confirmation pass that cannot run must not erase findings"""
-        mock_run.side_effect = self._dispatch(raises=FileNotFoundError('ffmpeg missing'))
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/stuck.mkv', duration=1290.0
-        )
-
-        assert has_warnings is True
-
-    @patch('subprocess.run')
-    def test_confirmation_timeout_keeps_event(self, mock_run):
-        """A confirmation pass that times out must not erase findings"""
-        mock_run.side_effect = self._dispatch(
-            raises=subprocess.TimeoutExpired(cmd='ffmpeg', timeout=300))
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/stuck.mkv', duration=1290.0
-        )
-
-        assert has_warnings is True
-
-
-    @patch('subprocess.run')
-    def test_failed_confirmation_run_keeps_event(self, mock_run):
-        """A non-zero ffmpeg exit is not evidence that the frames differ"""
-        mock_run.side_effect = self._dispatch(
-            confirm_stderr='Error opening input file', confirm_returncode=1)
-
-        checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/unreadable.mkv', duration=1290.0
-        )
-
-        assert has_warnings is True
-        assert not any('Discounted near-static' in line for line in scan_output)
+    def test_corroboration_is_capped_per_file(self, mock_run):
+        """Past the cap, events are not probed and fall to the uncorroborated path"""
+        events = [(float(i * 100), float(i * 100 + 8), 8.0) for i in range(1, 15)]
+        c, cd, w, wd, out = self._run(mock_run, events)
+        assert any('Corroborated the first 12 of 14' in line for line in out)
 
 
 class TestFrozenPercentageClamp:
@@ -917,19 +805,13 @@ class TestFrozenPercentageClamp:
     @patch('subprocess.run')
     def test_overlapping_events_counted_once(self, mock_run):
         """Two events over the same span count that span once"""
-        stderr = []
-        for start, end, duration in [(100.0, 400.0, 300.0), (110.0, 410.0, 300.0)]:
-            stderr.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: {start}")
-            stderr.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_duration: {duration}")
-            stderr.append(f"[freezedetect @ 0x1] lavfi.freezedetect.freeze_end: {end}")
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = "\n".join(stderr)
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
+        stderr = _freeze_stderr([(100.0, 400.0, 300.0), (110.0, 410.0, 300.0)])
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=stderr,
+            probe_stdout=_packets(97.0, 413.0, step=0.5))
 
         checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
+        _, _, has_warnings, warning_details, scan_output = checker._check_video_freeze(
             '/fake/gappy.mkv', duration=1000.0
         )
 
@@ -940,28 +822,34 @@ class TestFrozenPercentageClamp:
 
     @patch('subprocess.run')
     def test_percentage_never_exceeds_one_hundred(self, mock_run):
-        """An event running past the container duration still reports 100%"""
-        mock_result = Mock()
-        mock_result.returncode = 0
-        mock_result.stderr = (
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: 100.0\n"
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_duration: 5000.0\n"
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_end: 5100.0\n"
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: 110.0\n"
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_duration: 5000.0\n"
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_end: 5110.0"
-        )
-        mock_result.stdout = ''
-        mock_run.return_value = mock_result
+        """Overlapping events cannot report more frozen time than the runtime"""
+        stderr = _freeze_stderr([(10.0, 240.0, 230.0), (20.0, 250.0, 230.0)])
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=stderr, probe_stdout=_packets(7.0, 250.0, step=0.5))
 
         checker = PixelProbe()
-        has_warnings, warning_details, scan_output = checker._check_video_freeze(
-            '/fake/gappy.mkv', duration=1000.0
+        _, _, has_warnings, warning_details, _ = checker._check_video_freeze(
+            '/fake/gappy.mkv', duration=200.0
         )
 
         assert has_warnings is True
-        assert '1000.0s frozen' in warning_details[0]
+        assert '200.0s frozen' in warning_details[0]
         assert '100.0% of video' in warning_details[0]
+
+    @patch('subprocess.run')
+    def test_event_past_the_end_of_file_is_missing_content(self, mock_run):
+        """An event outrunning the container means packets are absent, which is damage"""
+        stderr = _freeze_stderr([(100.0, 5100.0, 5000.0)])
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=stderr, probe_stdout=_packets(90.0, 1000.0, step=0.5))
+
+        checker = PixelProbe()
+        is_corrupted, corruption_details, _, _, _ = checker._check_video_freeze(
+            '/fake/gappy.mkv', duration=1000.0
+        )
+
+        assert is_corrupted is True
+        assert any('Missing content' in d for d in corruption_details)
 
 
 class TestSettingsReachTheScanner:
@@ -976,7 +864,11 @@ class TestSettingsReachTheScanner:
         checker = PixelProbe()
         with patch_settings(**overrides):
             checker._check_video_freeze('/fake/video.mkv', duration=duration)
-        return ' '.join(str(part) for part in mock_run.call_args[0][0])
+        for call in mock_run.call_args_list:
+            joined = ' '.join(str(part) for part in call[0][0])
+            if 'freezedetect' in joined:
+                return joined
+        raise AssertionError('freeze pass never ran')
 
     @patch('subprocess.run')
     def test_minimum_duration_drives_the_detector(self, mock_run):
@@ -998,28 +890,23 @@ class TestSettingsReachTheScanner:
         assert 'freezedetect=n=-60dB:d=7.0' in cmd
 
     @patch('subprocess.run')
-    def test_card_suppression_can_be_switched_off(self, mock_run):
-        """An edge window of zero reports title and end cards instead of discounting them"""
-        stderr = (
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_start: 2.0\n"
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_duration: 8.0\n"
-            "[freezedetect @ 0x1] lavfi.freezedetect.freeze_end: 10.0"
-        )
-        result = Mock()
-        result.returncode = 0
-        result.stdout = ''
-        result.stderr = stderr
-        mock_run.return_value = result
+    def test_uncorroborated_minimum_reaches_the_scanner(self, mock_run):
+        """The excuse threshold decides whether a clean long freeze warns"""
+        events = _freeze_stderr([(100.0, 145.0, 45.0)])
         checker = PixelProbe()
 
-        with patch_settings(**{'detection.static_card_edge_secs': 60.0}):
-            on, _, out = checker._check_video_freeze('/fake/v.mkv', duration=1290.0)
-        assert on is False
-        assert any('Discounted static card' in line for line in out)
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=events, probe_stdout=_packets(97.0, 148.0))
+        with patch_settings(**{'detection.freeze_uncorroborated_min_secs': 60.0}):
+            _, _, warned, _, out = checker._check_video_freeze('/fake/v.mkv', duration=1290.0)
+        assert warned is False
+        assert any('Discounted still segment' in line for line in out)
 
-        with patch_settings(**{'detection.static_card_edge_secs': 0.0}):
-            on, details, out = checker._check_video_freeze('/fake/v.mkv', duration=1290.0)
-        assert on is True
+        mock_run.side_effect = freeze_router(
+            freeze_stderr=events, probe_stdout=_packets(97.0, 148.0))
+        with patch_settings(**{'detection.freeze_uncorroborated_min_secs': 30.0}):
+            _, _, warned, details, _ = checker._check_video_freeze('/fake/v.mkv', duration=1290.0)
+        assert warned is True
         assert '1 event(s)' in details[0]
 
     def test_data_integrity_threshold_is_a_setting(self, tmp_path):

--- a/tests/test_override_scoping.py
+++ b/tests/test_override_scoping.py
@@ -1,0 +1,105 @@
+"""Tests for scoped mark-as-good overrides."""
+
+from pixelprobe.models import db, ScanResult
+from pixelprobe.utils.overrides import (
+    classify_findings, encode_verdict, override_still_applies)
+
+
+class TestClassifyFindings:
+    def test_freeze_warning_classifies_as_freeze(self):
+        assert classify_findings(None, 'Video freeze warning: 2 event(s)') == ('freeze',)
+
+    def test_incomplete_file_classifies_as_incomplete(self):
+        assert classify_findings('Incomplete file: 24 unwritten region(s)', None) == ('incomplete',)
+
+    def test_corroborated_verdicts_have_their_own_classes(self):
+        assert classify_findings('Missing content: 1 frozen segment(s)', None) == ('missing-content',)
+        assert classify_findings('Decode failure: 2 frozen segment(s)', None) == ('decode',)
+
+    def test_unrecognised_findings_map_to_other(self):
+        assert classify_findings('Something brand new happened', None) == ('other',)
+
+    def test_multiple_classes_collect(self):
+        got = classify_findings('Incomplete file: x', 'Video freeze warning: y')
+        assert got == ('freeze', 'incomplete')
+
+    def test_empty_details_classify_as_nothing(self):
+        assert classify_findings(None, '') == ()
+        assert encode_verdict(()) is None
+
+
+class TestOverrideStillApplies:
+    HASH = 'a' * 64
+
+    def test_same_content_same_class_holds(self):
+        assert override_still_applies(
+            self.HASH, 'freeze', self.HASH,
+            None, 'Video freeze warning: 1 event(s)') is True
+
+    def test_changed_content_lapses(self):
+        assert override_still_applies(
+            self.HASH, 'freeze', 'b' * 64,
+            None, 'Video freeze warning: 1 event(s)') is False
+
+    def test_different_finding_class_lapses(self):
+        """Excusing a freeze must not hide a later incomplete-file verdict"""
+        assert override_still_applies(
+            self.HASH, 'freeze', self.HASH,
+            'Incomplete file: 3 unwritten region(s)', None) is False
+
+    def test_subset_of_excused_classes_holds(self):
+        assert override_still_applies(
+            self.HASH, 'freeze,temporal', self.HASH,
+            None, 'Video freeze warning: 1 event(s)') is True
+
+    def test_legacy_null_verdict_excuses_everything(self):
+        assert override_still_applies(
+            self.HASH, None, self.HASH,
+            'Incomplete file: x', 'Video freeze warning: y') is True
+
+    def test_legacy_null_hash_skips_content_check(self):
+        assert override_still_applies(
+            None, 'freeze', 'b' * 64,
+            None, 'Video freeze warning: 1 event(s)') is True
+
+    def test_mark_on_a_healthy_file_excuses_nothing(self):
+        """The 'none' sentinel a healthy-file mark stores hides no later finding"""
+        assert override_still_applies(
+            self.HASH, 'none', self.HASH,
+            None, 'Video freeze warning: 1 event(s)') is False
+        assert override_still_applies(
+            self.HASH, 'none', self.HASH, None, None) is True
+
+    def test_unknown_new_finding_never_hides(self):
+        """A finding class that did not exist at mark time must surface"""
+        assert override_still_applies(
+            self.HASH, 'freeze', self.HASH,
+            'Some future verdict text', None) is False
+
+
+class TestMarkAsGoodRecordsScope:
+    def test_mark_records_hash_date_and_verdict(self, authenticated_client, app):
+        with app.app_context():
+            db.create_all()
+            row = ScanResult(
+                file_path='/test/scoped.mkv', file_size=1000,
+                file_type='video/x-matroska', is_corrupted=False,
+                has_warnings=True,
+                warning_details='Video freeze warning: 1 event(s)',
+                file_hash='c' * 64, scan_status='completed')
+            db.session.add(row)
+            db.session.commit()
+            row_id = row.id
+
+        resp = authenticated_client.post('/api/mark-as-good',
+                                         json={'file_ids': [row_id]})
+        assert resp.status_code == 200
+
+        with app.app_context():
+            row = db.session.get(ScanResult, row_id)
+            assert row.marked_as_good is True
+            assert row.marked_good_hash == 'c' * 64
+            assert row.marked_good_verdict == 'freeze'
+            assert row.marked_good_date is not None
+            db.session.delete(row)
+            db.session.commit()

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -123,7 +123,7 @@ class TestResolution:
             db.session.commit()
             described = {s['key']: s for s in describe_settings()}
         assert described['detection.freeze_min_duration_secs']['is_default'] is False
-        assert described['detection.static_card_edge_secs']['is_default'] is True
+        assert described['detection.freeze_uncorroborated_min_secs']['is_default'] is True
 
 
 class TestSettingsApi:


### PR DESCRIPTION
Two changes sharing one idea: a verdict should be tied to evidence, not to a shape or a flag.

## Freeze corroboration

No duration threshold separates a damaged freeze from a held animation cel: across 34 verified warnings, real findings started at 7s while false positives reached 41s. So each candidate is now corroborated against the file itself.

- A packet probe (a handful of seeks, no decode) asks whether the stream has data where the clock kept running. Absent packets on a steady-cadence stream become a **Missing content** corruption verdict.
- A decode of just the window asks whether the decoder can produce frames. An error flood becomes a **Decode failure** corruption verdict.
- Neither signal means the picture stopped on purpose (title card, end plate, held cel) and the event is discounted, with the reason in the transcript. A single uncorroborated event past `detection.freeze_uncorroborated_min_secs` (default 60s) still warns, so a genuinely stuck source is not silent.

The cadence requirement keeps variable-frame-rate sources, which legitimately store nothing while the picture holds, from being called corrupt. Expected packets come from the file's declared average rate.

This subsumes the static-card and freeze-confirmation filters, removed along with their six settings. The black-frame filter stays, since a long fade to black is uncorroborated but should not warn.

Validated on real media through the full pipeline: a damaged Blu-ray rip reports 13,165 decoder errors as corruption, a torrent with four holes reports 92-99% absent packets per segment, and a static end card and a held animation cel are both discounted. In the verified 34-file sample this classifies every file correctly, promoting 8 from warnings to the corruption verdicts they deserved.

## Scoped mark-as-good

Marking a file good was a permanent mute that outranked every future finding. It now records the file hash and the class of finding excused, and lapses on rescan when the content changes or a different class of finding appears, in both the chunked and single-file save paths. Excusing a freeze warning can no longer hide a later incomplete-file verdict. History columns stay set after the override lapses, following the bitrot flag's keep-history pattern.

Existing marked rows are backfilled once at startup, deriving the excused class from their stored details. Rows with no details keep the old excuse-everything behaviour; a new mark on a healthy file stores a sentinel that excuses nothing.

## Review findings fixed before this PR

An adversarial review of the branch found seven issues, all fixed and covered by tests: the classifier now splits '; '-joined details so an unknown finding cannot hide behind a known neighbour; its markers match the strings the scanner actually emits; the verdict column fits every reachable class combination (verified at 38 chars on PostgreSQL, which VARCHAR(32) would have rejected and, because the backfill shared the DDL transaction, would have rolled back the schema while the model still declared the columns); the migration now commits DDL before backfilling; retirement runs on single-file rescans; and backfill timestamps are UTC on a non-UTC server (verified at 0s drift on a America/New_York instance).

## Test plan

- [x] 627 passed, 9 skipped
- [x] 24 new tests: 9 corroboration, 15 override scoping
- [x] Real-media validation of all four behaviour classes
- [x] Migration verified on PostgreSQL: backfill, scoping, idempotency, DDL-before-backfill, UTC, wide verdicts
- [x] Parse-clean on Python 3.10, 3.11, 3.12
- [x] App boots at 2.8.8; frontend builds

Settings registry shrinks from 15 to 10. Docs, glossary, and OpenAPI updated.